### PR TITLE
Sync menu items based on the cluster status

### DIFF
--- a/DaemonCommander/ResponseClasses.cs
+++ b/DaemonCommander/ResponseClasses.cs
@@ -5,7 +5,7 @@
         public string Name { get; set; }
         public string CrcStatus { get; set; }
         public string OpenshiftStatus { get; set; }
-        public long DiskUsage { get; set; }
+        public long DiskUse { get; set; }
         public long DiskSize { get; set; }
         public string Error { get; set; }
         public bool Success { get; set; }

--- a/Program.cs
+++ b/Program.cs
@@ -237,10 +237,20 @@ namespace tray_windows
                 copyOCLoginForDeveloperMenu.Enabled = true;
                 copyOCLoginForKubeadminMenu.Enabled = true;
             }
-            else if (string.IsNullOrEmpty(status.Error) && (status.CrcStatus == @"Running"))
+            else if (status.CrcStatus == @"Stopped")
             {
                 startMenu.Enabled = true;
                 deleteMenu.Enabled = true;
+                stopMenu.Enabled = false;
+                openWebConsoleMenu.Enabled = false;
+                copyOCLoginCommand.Enabled = false;
+                copyOCLoginForDeveloperMenu.Enabled = false;
+                copyOCLoginForKubeadminMenu.Enabled = false;
+            }
+            else if (!string.IsNullOrEmpty(status.Error) && status.Error.Contains("does not exist"))
+            {
+                startMenu.Enabled = true;
+                deleteMenu.Enabled = false;
                 stopMenu.Enabled = false;
                 openWebConsoleMenu.Enabled = false;
                 copyOCLoginCommand.Enabled = false;
@@ -251,7 +261,7 @@ namespace tray_windows
             {
                 startMenu.Enabled = true;
                 stopMenu.Enabled = false;
-                deleteMenu.Enabled = false;
+                deleteMenu.Enabled = true;
                 openWebConsoleMenu.Enabled = false;
                 copyOCLoginCommand.Enabled = false;
                 copyOCLoginForDeveloperMenu.Enabled = false;

--- a/StatusForm.cs
+++ b/StatusForm.cs
@@ -36,7 +36,7 @@ namespace tray_windows
 
                 CrcStatus.Text = status.CrcStatus;
                 OpenShiftStatus.Text = status.OpenshiftStatus;
-                DiskUsage.Text = string.Format("{0} of {1} (Inside the CRC VM)", FileSize.HumanReadable(status.DiskUsage), FileSize.HumanReadable(status.DiskSize));
+                DiskUsage.Text = string.Format("{0} of {1} (Inside the CRC VM)", FileSize.HumanReadable(status.DiskUse), FileSize.HumanReadable(status.DiskSize));
                 CacheUsage.Text = FileSize.HumanReadable(GetFolderSize.SizeInBytes(cacheFolderPath));
                 CacheFolder.Text = cacheFolderPath;
             }


### PR DESCRIPTION
When status has errors it could be due to a cluster not
existing or a cluster exists but not able to get the status
from it, it the previous case we cannot delete the cluster since
it doesn't exist yet, whereas in the second case we are able to
perform a delete, we decide if a cluster exists or not based on the
Error reported by the status result struct.