### PR TITLE
Increase size of label boxes to fit the whole string

### DIFF
--- a/AboutForm.Designer.cs
+++ b/AboutForm.Designer.cs
@@ -50,9 +50,10 @@
             this.label1.AutoSize = true;
             this.label1.Dock = System.Windows.Forms.DockStyle.Left;
             this.label1.Font = new System.Drawing.Font("Segoe UI Semibold", 9.857143F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(3, 0);
+            this.label1.Location = new System.Drawing.Point(2, 0);
+            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(447, 40);
+            this.label1.Size = new System.Drawing.Size(256, 21);
             this.label1.TabIndex = 5;
             this.label1.Text = "Red Hat CodeReady Containers version:";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -62,9 +63,10 @@
             this.label2.AutoSize = true;
             this.label2.Dock = System.Windows.Forms.DockStyle.Left;
             this.label2.Font = new System.Drawing.Font("Segoe UI Semibold", 9.857143F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(3, 40);
+            this.label2.Location = new System.Drawing.Point(2, 21);
+            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(621, 40);
+            this.label2.Size = new System.Drawing.Size(357, 21);
             this.label2.TabIndex = 6;
             this.label2.Text = "Red Hat OpenShift Container platform bundled version:";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -74,9 +76,10 @@
             this.label3.AutoSize = true;
             this.label3.Dock = System.Windows.Forms.DockStyle.Left;
             this.label3.Font = new System.Drawing.Font("Segoe UI Semibold", 9.857143F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(3, 80);
+            this.label3.Location = new System.Drawing.Point(2, 42);
+            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(151, 44);
+            this.label3.Size = new System.Drawing.Size(87, 25);
             this.label3.TabIndex = 7;
             this.label3.Text = "Tray version:";
             this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -87,9 +90,10 @@
             this.linkLabel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.linkLabel1.Font = new System.Drawing.Font("Calibri", 9.857143F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.linkLabel1.ImageAlign = System.Drawing.ContentAlignment.BottomCenter;
-            this.linkLabel1.Location = new System.Drawing.Point(46, 0);
+            this.linkLabel1.Location = new System.Drawing.Point(25, 0);
+            this.linkLabel1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.linkLabel1.Name = "linkLabel1";
-            this.linkLabel1.Size = new System.Drawing.Size(214, 43);
+            this.linkLabel1.Size = new System.Drawing.Size(116, 23);
             this.linkLabel1.TabIndex = 8;
             this.linkLabel1.TabStop = true;
             this.linkLabel1.Text = "Documentation";
@@ -101,9 +105,10 @@
             this.pictureBox2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.pictureBox2.Image = global::tray_windows.Resource.crc_logo;
-            this.pictureBox2.Location = new System.Drawing.Point(287, 12);
+            this.pictureBox2.Location = new System.Drawing.Point(157, 7);
+            this.pictureBox2.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.pictureBox2.Name = "pictureBox2";
-            this.pictureBox2.Size = new System.Drawing.Size(397, 172);
+            this.pictureBox2.Size = new System.Drawing.Size(217, 93);
             this.pictureBox2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.pictureBox2.TabIndex = 1;
             this.pictureBox2.TabStop = false;
@@ -112,9 +117,10 @@
             // 
             this.pictureBox3.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pictureBox3.Image = global::tray_windows.Resource.web_icon;
-            this.pictureBox3.Location = new System.Drawing.Point(3, 3);
+            this.pictureBox3.Location = new System.Drawing.Point(2, 2);
+            this.pictureBox3.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.pictureBox3.Name = "pictureBox3";
-            this.pictureBox3.Size = new System.Drawing.Size(37, 37);
+            this.pictureBox3.Size = new System.Drawing.Size(19, 19);
             this.pictureBox3.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.pictureBox3.TabIndex = 11;
             this.pictureBox3.TabStop = false;
@@ -123,9 +129,10 @@
             // 
             this.CrcVersionLabel.AutoSize = true;
             this.CrcVersionLabel.Font = new System.Drawing.Font("Segoe UI Semibold", 9.857143F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.CrcVersionLabel.Location = new System.Drawing.Point(637, 0);
+            this.CrcVersionLabel.Location = new System.Drawing.Point(365, 0);
+            this.CrcVersionLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.CrcVersionLabel.Name = "CrcVersionLabel";
-            this.CrcVersionLabel.Size = new System.Drawing.Size(71, 32);
+            this.CrcVersionLabel.Size = new System.Drawing.Size(41, 19);
             this.CrcVersionLabel.TabIndex = 12;
             this.CrcVersionLabel.Text = "||||||||";
             // 
@@ -133,9 +140,10 @@
             // 
             this.OcpVersion.AutoSize = true;
             this.OcpVersion.Font = new System.Drawing.Font("Segoe UI Semibold", 9.857143F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.OcpVersion.Location = new System.Drawing.Point(637, 40);
+            this.OcpVersion.Location = new System.Drawing.Point(365, 21);
+            this.OcpVersion.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.OcpVersion.Name = "OcpVersion";
-            this.OcpVersion.Size = new System.Drawing.Size(71, 32);
+            this.OcpVersion.Size = new System.Drawing.Size(41, 19);
             this.OcpVersion.TabIndex = 14;
             this.OcpVersion.Text = "||||||||";
             // 
@@ -143,55 +151,59 @@
             // 
             this.TrayVersion.AutoSize = true;
             this.TrayVersion.Font = new System.Drawing.Font("Segoe UI Semibold", 9.857143F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.TrayVersion.Location = new System.Drawing.Point(637, 80);
+            this.TrayVersion.Location = new System.Drawing.Point(365, 42);
+            this.TrayVersion.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.TrayVersion.Name = "TrayVersion";
-            this.TrayVersion.Size = new System.Drawing.Size(71, 32);
+            this.TrayVersion.Size = new System.Drawing.Size(41, 19);
             this.TrayVersion.TabIndex = 15;
             this.TrayVersion.Text = "||||||||";
             // 
             // tableLayoutPanel1
             // 
             this.tableLayoutPanel1.ColumnCount = 2;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 73.24902F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 26.75097F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 71.65354F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 28.34646F));
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.OcpVersion, 1, 1);
             this.tableLayoutPanel1.Controls.Add(this.TrayVersion, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.label2, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.label3, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.CrcVersionLabel, 1, 0);
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(52, 263);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(11, 142);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 3;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 44F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(866, 124);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(508, 67);
             this.tableLayoutPanel1.TabIndex = 16;
             // 
             // tableLayoutPanel2
             // 
             this.tableLayoutPanel2.ColumnCount = 2;
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 43F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 23F));
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 91.98113F));
             this.tableLayoutPanel2.Controls.Add(this.pictureBox3, 0, 0);
             this.tableLayoutPanel2.Controls.Add(this.linkLabel1, 1, 0);
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(354, 484);
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(193, 262);
+            this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 1;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(263, 43);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(143, 23);
             this.tableLayoutPanel2.TabIndex = 17;
             // 
             // AboutForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(11F, 24F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(971, 563);
+            this.ClientSize = new System.Drawing.Size(530, 305);
             this.Controls.Add(this.tableLayoutPanel2);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Controls.Add(this.pictureBox2);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "AboutForm";

--- a/StatusForm.Designer.cs
+++ b/StatusForm.Designer.cs
@@ -37,8 +37,8 @@
             this.DiskUsage = new System.Windows.Forms.Label();
             this.CacheUsage = new System.Windows.Forms.Label();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.CacheFolder = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
+            this.CacheFolder = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -50,7 +50,7 @@
             this.label2.Location = new System.Drawing.Point(6, 0);
             this.label2.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(158, 23);
+            this.label2.Size = new System.Drawing.Size(202, 23);
             this.label2.TabIndex = 1;
             this.label2.Text = "CodeReady Containers status:";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -63,7 +63,7 @@
             this.label3.Location = new System.Drawing.Point(6, 23);
             this.label3.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(158, 23);
+            this.label3.Size = new System.Drawing.Size(202, 23);
             this.label3.TabIndex = 2;
             this.label3.Text = "OpenShift status:";
             this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -76,7 +76,7 @@
             this.label4.Location = new System.Drawing.Point(6, 46);
             this.label4.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(158, 23);
+            this.label4.Size = new System.Drawing.Size(202, 23);
             this.label4.TabIndex = 3;
             this.label4.Text = "Disk Usage:";
             this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -89,7 +89,7 @@
             this.label5.Location = new System.Drawing.Point(6, 69);
             this.label5.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(158, 23);
+            this.label5.Size = new System.Drawing.Size(202, 23);
             this.label5.TabIndex = 4;
             this.label5.Text = "Cache Usage:";
             this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -99,11 +99,11 @@
             this.CrcStatus.AutoSize = true;
             this.CrcStatus.Dock = System.Windows.Forms.DockStyle.Fill;
             this.CrcStatus.Font = new System.Drawing.Font("Segoe UI", 9.857143F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.CrcStatus.Location = new System.Drawing.Point(176, 0);
+            this.CrcStatus.Location = new System.Drawing.Point(220, 0);
             this.CrcStatus.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.CrcStatus.Name = "CrcStatus";
             this.CrcStatus.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.CrcStatus.Size = new System.Drawing.Size(322, 23);
+            this.CrcStatus.Size = new System.Drawing.Size(278, 23);
             this.CrcStatus.TabIndex = 5;
             this.CrcStatus.Text = "||||||||";
             this.CrcStatus.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -113,10 +113,10 @@
             this.OpenShiftStatus.AutoSize = true;
             this.OpenShiftStatus.Dock = System.Windows.Forms.DockStyle.Fill;
             this.OpenShiftStatus.Font = new System.Drawing.Font("Segoe UI", 9.857143F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.OpenShiftStatus.Location = new System.Drawing.Point(176, 23);
+            this.OpenShiftStatus.Location = new System.Drawing.Point(220, 23);
             this.OpenShiftStatus.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.OpenShiftStatus.Name = "OpenShiftStatus";
-            this.OpenShiftStatus.Size = new System.Drawing.Size(322, 23);
+            this.OpenShiftStatus.Size = new System.Drawing.Size(278, 23);
             this.OpenShiftStatus.TabIndex = 6;
             this.OpenShiftStatus.Text = "||||||||";
             this.OpenShiftStatus.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -125,11 +125,11 @@
             // 
             this.DiskUsage.Dock = System.Windows.Forms.DockStyle.Fill;
             this.DiskUsage.Font = new System.Drawing.Font("Segoe UI", 9.857143F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.DiskUsage.Location = new System.Drawing.Point(176, 46);
+            this.DiskUsage.Location = new System.Drawing.Point(220, 46);
             this.DiskUsage.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.DiskUsage.Name = "DiskUsage";
             this.DiskUsage.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.DiskUsage.Size = new System.Drawing.Size(322, 23);
+            this.DiskUsage.Size = new System.Drawing.Size(278, 23);
             this.DiskUsage.TabIndex = 7;
             this.DiskUsage.Text = "||||||||";
             this.DiskUsage.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -139,10 +139,10 @@
             this.CacheUsage.AutoSize = true;
             this.CacheUsage.Dock = System.Windows.Forms.DockStyle.Fill;
             this.CacheUsage.Font = new System.Drawing.Font("Segoe UI", 9.857143F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.CacheUsage.Location = new System.Drawing.Point(176, 69);
+            this.CacheUsage.Location = new System.Drawing.Point(220, 69);
             this.CacheUsage.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.CacheUsage.Name = "CacheUsage";
-            this.CacheUsage.Size = new System.Drawing.Size(322, 23);
+            this.CacheUsage.Size = new System.Drawing.Size(278, 23);
             this.CacheUsage.TabIndex = 8;
             this.CacheUsage.Text = "||||||||";
             this.CacheUsage.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -150,8 +150,8 @@
             // tableLayoutPanel1
             // 
             this.tableLayoutPanel1.ColumnCount = 2;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.73254F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 66.26746F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 42.65873F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 57.34127F));
             this.tableLayoutPanel1.Controls.Add(this.label1, 0, 4);
             this.tableLayoutPanel1.Controls.Add(this.CacheFolder, 1, 4);
             this.tableLayoutPanel1.Controls.Add(this.label2, 0, 0);
@@ -175,19 +175,6 @@
             this.tableLayoutPanel1.Size = new System.Drawing.Size(504, 119);
             this.tableLayoutPanel1.TabIndex = 9;
             // 
-            // CacheFolder
-            // 
-            this.CacheFolder.AutoSize = true;
-            this.CacheFolder.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.CacheFolder.Font = new System.Drawing.Font("Segoe UI", 9.857143F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.CacheFolder.Location = new System.Drawing.Point(176, 92);
-            this.CacheFolder.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
-            this.CacheFolder.Name = "CacheFolder";
-            this.CacheFolder.Size = new System.Drawing.Size(322, 27);
-            this.CacheFolder.TabIndex = 10;
-            this.CacheFolder.Text = "||||||||";
-            this.CacheFolder.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
             // label1
             // 
             this.label1.AutoSize = true;
@@ -196,10 +183,23 @@
             this.label1.Location = new System.Drawing.Point(6, 92);
             this.label1.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(158, 27);
+            this.label1.Size = new System.Drawing.Size(202, 27);
             this.label1.TabIndex = 11;
             this.label1.Text = "Cache Folder:";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // CacheFolder
+            // 
+            this.CacheFolder.AutoSize = true;
+            this.CacheFolder.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.CacheFolder.Font = new System.Drawing.Font("Segoe UI", 9.857143F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.CacheFolder.Location = new System.Drawing.Point(220, 92);
+            this.CacheFolder.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.CacheFolder.Name = "CacheFolder";
+            this.CacheFolder.Size = new System.Drawing.Size(278, 27);
+            this.CacheFolder.TabIndex = 10;
+            this.CacheFolder.Text = "||||||||";
+            this.CacheFolder.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // StatusForm
             // 


### PR DESCRIPTION
Last words of few labels in status and about forms were truncated/
not viewable due to smaller size, this is to fix that issue.

Example below from the status window, but this also happens for the about window!
## Before
![](https://i.imgur.com/t8YuwIh.png)

## After
![](https://i.imgur.com/EG6v9WP.png)