### PR TITLE
Issue #19 Fix JSON parsing of startResult

### DIFF
--- a/DaemonCommander/DaemonCommander.cs
+++ b/DaemonCommander/DaemonCommander.cs
@@ -161,7 +161,7 @@ namespace tray_windows.Daemon
 		{
 			try
 			{
-				var resp = new byte[2048];
+				var resp = new byte[16 * 1024];
 				daemonSocket.Connect(daemonSocketEp);
 				var cmd = $"{{\"command\":\"{command}\"}}";
 				byte[] msg = Encoding.ASCII.GetBytes(cmd);

--- a/DaemonCommander/Handlers.cs
+++ b/DaemonCommander/Handlers.cs
@@ -22,6 +22,11 @@ namespace tray_windows
                 DisplayMessageBox.Error(ex.Message);
                 return null;
             }
+            catch (JsonException ex)
+            {
+                DisplayMessageBox.Error(ex.Message);
+                return null;
+            }
         }
 
         public static StopResult HandleStop()

--- a/DaemonCommander/ResponseClasses.cs
+++ b/DaemonCommander/ResponseClasses.cs
@@ -24,10 +24,20 @@ namespace tray_windows
 
     public class ClusterConfig
     {
+        public string ClusterCACert { get; set; }
         public string KubeConfig { get; set; }
         public string KubeAdminPass { get; set; }
         public string ClusterAPI { get; set; }
         public string WebConsoleURL { get; set; }
+        public ProxyConfig ProxyConfig;
+    }
+
+    public struct ProxyConfig
+    {
+        public string HTTPProxy;
+        public string HTTPSProxy;
+        public string[] noProxy;
+        public string ProxyCACert;
     }
 
     public class StopResult


### PR DESCRIPTION
Handle JSON parsing exception in start handler
Increase the size of byte array used to receive
response from daemon

Fixes #19 
Fixes #20 
