### PR TITLE
Containerized build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+CONTAINER_RUNTIME ?= podman
+
+.PHONY: containerized
+containerized:
+	${CONTAINER_RUNTIME} build -t tray-build -f images/ .
+	${CONTAINER_RUNTIME} run --name tray-build tray-build sh -c "nuget restore && xbuild tray-windows.sln"
+	${CONTAINER_RUNTIME} cp tray-build:/app/bin ./bin
+	${CONTAINER_RUNTIME} rm tray-build
+	#${CONTAINER_RUNTIME} rmi tray-build  # this forces a rebuild of the toolchain each time

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ For the CRC project head over to: https://github.com/code-ready/crc
 
 [![Build status](https://ci.appveyor.com/api/projects/status/11upwe64sapyhoq7/branch/master?retina=true)](https://ci.appveyor.com/project/anjannath/tray-windows/branch/master)
 
+
 ### How to use
 
 1. You need the latest CRC binary first. Download it from https://github.com/code-ready/crc/releases
@@ -13,14 +14,28 @@ For the CRC project head over to: https://github.com/code-ready/crc
 4. Extract the contents of `tray-windows.zip` and double click on **tray-windows**
 5. _Pull Secret_ and _Bundle_ must be configured with `crc config set pull-secret-file` and `crc config set bundle`
 
+
 ### Screenshots
 
 <img src="https://i.imgur.com/wDXWrXH.png" alt="shot2" width="270" height="230"/>
 
+
 ### Steps to build
+
+#### Windows
 
 **Note: You need Visual Studio to build**
 
 1. Clone this repository `git clone https://github.com/code-ready/tray-windows.git`.
 2. Import the solution `tray-windows.sln` to Visual Studio .
 3. Build from the Build menu on in Visual Studio.
+
+#### Linux
+
+A containerized build is available. This uses a Fedora container image and Mono.
+
+```
+$ make containerized
+```
+
+the results are copied to `./bin/` and can be run on Windows.

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.fedoraproject.org/fedora:latest
+WORKDIR /app
+
+RUN dnf install -y mono-devel nuget && \
+    nuget update -self
+
+COPY . .


### PR DESCRIPTION
Fixes #23 

This allows cross platform builds, eg. from Linux that target Windows.

```
$ make containerized
```

The binaries will be copied to `./bin`.
