### PR TITLE
Fix nullexception in the settings form

### DIFF
--- a/Forms/CrcSettingsForm.Designer.cs
+++ b/Forms/CrcSettingsForm.Designer.cs
@@ -87,14 +87,14 @@
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
-            // tabControl1
+            // tabs
             // 
             this.tabs.AccessibleName = "Settings tab";
             this.tabs.Controls.Add(this.properties_tab);
             this.tabs.Controls.Add(this.advance_tab);
             this.tabs.Location = new System.Drawing.Point(7, 7);
             this.tabs.Margin = new System.Windows.Forms.Padding(2);
-            this.tabs.Name = "tabControl1";
+            this.tabs.Name = "tabs";
             this.tabs.SelectedIndex = 0;
             this.tabs.Size = new System.Drawing.Size(471, 374);
             this.tabs.TabIndex = 0;
@@ -493,7 +493,7 @@
             // refreshButton2
             // 
             this.refreshButton2.AccessibleName = "Refresh button";
-            this.refreshButton2.Location = new System.Drawing.Point(304, 322);
+            this.refreshButton2.Location = new System.Drawing.Point(304, 216);
             this.refreshButton2.Margin = new System.Windows.Forms.Padding(2);
             this.refreshButton2.Name = "refreshButton2";
             this.refreshButton2.Size = new System.Drawing.Size(61, 22);
@@ -505,7 +505,7 @@
             // applyButton2
             // 
             this.applyButton2.AccessibleName = "Apply button";
-            this.applyButton2.Location = new System.Drawing.Point(393, 322);
+            this.applyButton2.Location = new System.Drawing.Point(393, 216);
             this.applyButton2.Margin = new System.Windows.Forms.Padding(2);
             this.applyButton2.Name = "applyButton2";
             this.applyButton2.Size = new System.Drawing.Size(63, 22);
@@ -639,7 +639,7 @@
             this.contextMenuStrip1.Name = "contextMenuStrip1";
             this.contextMenuStrip1.Size = new System.Drawing.Size(61, 4);
             // 
-            // openFileDialog1
+            // fileRequester
             // 
             this.fileRequester.FileName = "openFileDialog1";
             this.fileRequester.InitialDirectory = "$env:USERPROFILE";

--- a/Forms/CrcSettingsForm.cs
+++ b/Forms/CrcSettingsForm.cs
@@ -20,14 +20,15 @@ namespace CRCTray
         public CrcSettingsForm()
         {
             InitializeComponent();
+            getConfigurationAndResetChanged();
         }
 
         private void getConfigurationAndResetChanged()
         {
-            currentConfig = TaskHandlers.ConfigView();
-            loadConfigurationValues(currentConfig);
             this.changedConfigs = new Dictionary<string, dynamic>();
             this.configsNeedingUnset = new List<string>();
+            currentConfig = TaskHandlers.ConfigView();
+            loadConfigurationValues(currentConfig);
             configChanged = false;
         }
 
@@ -38,8 +39,6 @@ namespace CRCTray
             Text = @"CodeReady Containers - Settings";
             this.FormClosing += CrcSettingsForm_FormClosing;
             this.tabs.SelectedIndexChanged += tabs_SelectedIndexChanged;
-
-            getConfigurationAndResetChanged();
         }
 
         private void tabs_SelectedIndexChanged(object sender, EventArgs e)

--- a/Forms/CrcSettingsForm.cs
+++ b/Forms/CrcSettingsForm.cs
@@ -11,7 +11,6 @@ namespace CRCTray
 {
     public partial class CrcSettingsForm : Form
     {
-        const int TotalPreflightChecks = 15;
         bool configChanged = false;
         List<string> configsNeedingUnset;
         ConfigResult currentConfig;

--- a/Forms/CrcSettingsForm.resx
+++ b/Forms/CrcSettingsForm.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>140, 17</value>
   </metadata>
-  <metadata name="openFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>172, 17</value>
+  <metadata name="fileRequester.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
 </root>


### PR DESCRIPTION
- Create the changedConfigs dictionary before using it
- Move the refresh and apply buttons a bit up so that the advanced tab window can resize to its content size