### PR TITLE
misc fixes around status in the menu and status window

### DIFF
--- a/Communication/DaemonCommander.cs
+++ b/Communication/DaemonCommander.cs
@@ -70,6 +70,11 @@ namespace CRCTray.Communication
 			return JsonSerializer.Deserialize<SetUnsetConfig>(SendCommand(cmd));
 		}
 
+		public static Logs GetLogs()
+        {
+			return getResultsForBasicCommand<Logs>(BasicCommands.Logs);
+        }
+
 		private static string SendBasicCommand(string command)
 		{
             var cmd = JsonSerializer.Serialize(new BasicCommand(command));
@@ -113,6 +118,8 @@ namespace CRCTray.Communication
 
 			catch (SocketException e)
 			{
+				Console.WriteLine("Exception occured");
+				daemonSocket.Close();
 				throw e;
 			}
 		}

--- a/Communication/DaemonCommander.cs
+++ b/Communication/DaemonCommander.cs
@@ -110,7 +110,6 @@ namespace CRCTray.Communication
 				byte[] msg = Encoding.ASCII.GetBytes(cmd);
 				daemonSocket.Send(msg);
 				daemonSocket.Receive(resp);
-				daemonSocket.Close();
 
 				var result = Encoding.ASCII.GetString(resp);
 				return result.Replace("\0", string.Empty);
@@ -119,7 +118,6 @@ namespace CRCTray.Communication
 			catch (SocketException e)
 			{
 				Console.WriteLine("Exception occured");
-				daemonSocket.Close();
 				throw e;
 			}
 		}

--- a/Communication/Enums.cs
+++ b/Communication/Enums.cs
@@ -13,6 +13,8 @@ namespace CRCTray.Communication
 
         internal const string ConsoleUrl = "webconsoleurl";
         internal const string Config = "getconfig";
+
+        internal const string Logs = "logs";
     }
 
 }

--- a/Communication/ResponseClasses.cs
+++ b/Communication/ResponseClasses.cs
@@ -18,7 +18,7 @@ namespace CRCTray.Communication
     {
         public string Name { get; set; }
         public string Status { get; set; }
-        public ClusterConfig ClusterConfig;
+        public ClusterConfig ClusterConfig { get; set; }
         public bool KubeletStarted { get; set; }
     }
 
@@ -29,15 +29,14 @@ namespace CRCTray.Communication
         public string KubeAdminPass { get; set; }
         public string ClusterAPI { get; set; }
         public string WebConsoleURL { get; set; }
-        public ProxyConfig ProxyConfig;
+        public ProxyConfig ProxyConfig { get; set; } 
     }
 
     public struct ProxyConfig
     {
-        public string HTTPProxy;
-        public string HTTPSProxy;
-        public string[] noProxy;
-        public string ProxyCACert;
+        public string HTTPProxy { get; set; }
+        public string HTTPSProxy { get; set; }
+        public string ProxyCACert { get; set; }
     }
 
     public class StopResult
@@ -57,8 +56,7 @@ namespace CRCTray.Communication
 
     public class ConsoleResult
     {
-        public ClusterConfig ClusterConfig;
-        public int State { get; set; }
+        public ClusterConfig ClusterConfig { get; set; }
         public bool Success { get; set; }
         public string Error { get; set; }
     }

--- a/Communication/ResponseClasses.cs
+++ b/Communication/ResponseClasses.cs
@@ -166,4 +166,10 @@ namespace CRCTray.Communication
         public string Error { get; set; }
         public string[] Properties { get; set; }
     }
+
+    struct Logs
+    {
+        public bool Success { get; set; }
+        public string[] Messages { get; set; }
+    }
 }

--- a/Communication/ResponseClasses.cs
+++ b/Communication/ResponseClasses.cs
@@ -111,6 +111,12 @@ namespace CRCTray.Communication
         [JsonPropertyName("network-mode")]
         public string NetworkMode { get; set; }
 
+        [JsonPropertyName("consent-telemetry")]
+        public string ConsentTelemetry { get; set; }
+
+        [JsonPropertyName("autostart-tray")]
+        public bool AutostartTray { get; set; }
+
         [JsonPropertyName("skip-check-admin-helper-cached")]
         public bool SkipCheckAdminHelperCached { get; set; }
 

--- a/Communication/ResponseClasses.cs
+++ b/Communication/ResponseClasses.cs
@@ -7,6 +7,7 @@ namespace CRCTray.Communication
         public string Name { get; set; }
         public string CrcStatus { get; set; }
         public string OpenshiftStatus { get; set; }
+        public string OpenshiftVersion { get; set; }
         public long DiskUse { get; set; }
         public long DiskSize { get; set; }
         public string Error { get; set; }

--- a/Forms/CrcSettingsForm.Designer.cs
+++ b/Forms/CrcSettingsForm.Designer.cs
@@ -45,6 +45,7 @@
             this.label5 = new System.Windows.Forms.Label();
             this.useProxyTick = new System.Windows.Forms.CheckBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.consentTelemetryCheckBox = new System.Windows.Forms.CheckBox();
             this.label23 = new System.Windows.Forms.Label();
             this.label22 = new System.Windows.Forms.Label();
             this.diskSizeNumBox = new System.Windows.Forms.NumericUpDown();
@@ -60,6 +61,7 @@
             this.refreshButton2 = new System.Windows.Forms.Button();
             this.applyButton2 = new System.Windows.Forms.Button();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.autostartTrayCheckBox = new System.Windows.Forms.CheckBox();
             this.nameServerTxtBox = new System.Windows.Forms.TextBox();
             this.label9 = new System.Windows.Forms.Label();
             this.disableUpdateCheckBox = new System.Windows.Forms.CheckBox();
@@ -70,8 +72,6 @@
             this.SkipCheckUserInHypervAdminsGroup = new System.Windows.Forms.CheckBox();
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.fileRequester = new System.Windows.Forms.OpenFileDialog();
-            this.autostartTrayCheckBox = new System.Windows.Forms.CheckBox();
-            this.consentTelemetryCheckBox = new System.Windows.Forms.CheckBox();
             this.tabs.SuspendLayout();
             this.properties_tab.SuspendLayout();
             this.groupBox2.SuspendLayout();
@@ -285,6 +285,17 @@
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "General";
             // 
+            // consentTelemetryCheckBox
+            // 
+            this.consentTelemetryCheckBox.AutoSize = true;
+            this.consentTelemetryCheckBox.Location = new System.Drawing.Point(8, 150);
+            this.consentTelemetryCheckBox.Name = "consentTelemetryCheckBox";
+            this.consentTelemetryCheckBox.Size = new System.Drawing.Size(207, 21);
+            this.consentTelemetryCheckBox.TabIndex = 17;
+            this.consentTelemetryCheckBox.Text = "Report telemetry to Red Hat";
+            this.consentTelemetryCheckBox.UseVisualStyleBackColor = true;
+            this.consentTelemetryCheckBox.CheckedChanged += new System.EventHandler(this.consentTelemetryCheckBox_CheckedChanged);
+            // 
             // label23
             // 
             this.label23.AutoSize = true;
@@ -323,11 +334,6 @@
             0,
             0,
             0});
-            this.memoryNumBox.Minimum = new decimal(new int[] {
-            9126,
-            0,
-            0,
-            0});
             this.memoryNumBox.Name = "memoryNumBox";
             this.memoryNumBox.Size = new System.Drawing.Size(87, 22);
             this.memoryNumBox.TabIndex = 4;
@@ -343,11 +349,6 @@
             this.cpusNumBox.AccessibleName = "vCPUs";
             this.cpusNumBox.Location = new System.Drawing.Point(105, 21);
             this.cpusNumBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.cpusNumBox.Minimum = new decimal(new int[] {
-            4,
-            0,
-            0,
-            0});
             this.cpusNumBox.Name = "cpusNumBox";
             this.cpusNumBox.Size = new System.Drawing.Size(87, 22);
             this.cpusNumBox.TabIndex = 3;
@@ -470,6 +471,17 @@
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Misc";
             // 
+            // autostartTrayCheckBox
+            // 
+            this.autostartTrayCheckBox.AutoSize = true;
+            this.autostartTrayCheckBox.Location = new System.Drawing.Point(4, 66);
+            this.autostartTrayCheckBox.Name = "autostartTrayCheckBox";
+            this.autostartTrayCheckBox.Size = new System.Drawing.Size(199, 21);
+            this.autostartTrayCheckBox.TabIndex = 21;
+            this.autostartTrayCheckBox.Text = "Automatically start on login";
+            this.autostartTrayCheckBox.UseVisualStyleBackColor = true;
+            this.autostartTrayCheckBox.CheckedChanged += new System.EventHandler(this.autostartTrayCheckBox_CheckedChanged);
+            // 
             // nameServerTxtBox
             // 
             this.nameServerTxtBox.AccessibleName = "Nameserver";
@@ -542,7 +554,7 @@
             this.SkipCheckWindowsVersion.AccessibleName = "Skip Windows version check";
             this.SkipCheckWindowsVersion.AutoSize = true;
             this.SkipCheckWindowsVersion.Location = new System.Drawing.Point(4, 68);
-            this.SkipCheckWindowsVersion.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.SkipCheckWindowsVersion.Margin = new System.Windows.Forms.Padding(4);
             this.SkipCheckWindowsVersion.Name = "SkipCheckWindowsVersion";
             this.SkipCheckWindowsVersion.Size = new System.Drawing.Size(204, 21);
             this.SkipCheckWindowsVersion.TabIndex = 18;
@@ -556,7 +568,7 @@
             this.SkipCheckRunningAsAdmin.AccessibleName = "Skip administrator check";
             this.SkipCheckRunningAsAdmin.AutoSize = true;
             this.SkipCheckRunningAsAdmin.Location = new System.Drawing.Point(4, 36);
-            this.SkipCheckRunningAsAdmin.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.SkipCheckRunningAsAdmin.Margin = new System.Windows.Forms.Padding(4);
             this.SkipCheckRunningAsAdmin.Name = "SkipCheckRunningAsAdmin";
             this.SkipCheckRunningAsAdmin.Size = new System.Drawing.Size(264, 21);
             this.SkipCheckRunningAsAdmin.TabIndex = 17;
@@ -570,7 +582,7 @@
             this.SkipCheckUserInHypervAdminsGroup.AccessibleName = "Skip Hyper-V admin check";
             this.SkipCheckUserInHypervAdminsGroup.AutoSize = true;
             this.SkipCheckUserInHypervAdminsGroup.Location = new System.Drawing.Point(4, 4);
-            this.SkipCheckUserInHypervAdminsGroup.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.SkipCheckUserInHypervAdminsGroup.Margin = new System.Windows.Forms.Padding(4);
             this.SkipCheckUserInHypervAdminsGroup.Name = "SkipCheckUserInHypervAdminsGroup";
             this.SkipCheckUserInHypervAdminsGroup.Size = new System.Drawing.Size(282, 21);
             this.SkipCheckUserInHypervAdminsGroup.TabIndex = 16;
@@ -588,28 +600,6 @@
             // 
             this.fileRequester.FileName = "openFileDialog1";
             this.fileRequester.InitialDirectory = "$env:USERPROFILE";
-            // 
-            // autostartTrayCheckBox
-            // 
-            this.autostartTrayCheckBox.AutoSize = true;
-            this.autostartTrayCheckBox.Location = new System.Drawing.Point(4, 66);
-            this.autostartTrayCheckBox.Name = "autostartTrayCheckBox";
-            this.autostartTrayCheckBox.Size = new System.Drawing.Size(199, 21);
-            this.autostartTrayCheckBox.TabIndex = 21;
-            this.autostartTrayCheckBox.Text = "Automatically start on login";
-            this.autostartTrayCheckBox.UseVisualStyleBackColor = true;
-            this.autostartTrayCheckBox.CheckedChanged += new System.EventHandler(this.autostartTrayCheckBox_CheckedChanged);
-            // 
-            // consentTelemetryCheckBox
-            // 
-            this.consentTelemetryCheckBox.AutoSize = true;
-            this.consentTelemetryCheckBox.Location = new System.Drawing.Point(8, 150);
-            this.consentTelemetryCheckBox.Name = "consentTelemetryCheckBox";
-            this.consentTelemetryCheckBox.Size = new System.Drawing.Size(207, 21);
-            this.consentTelemetryCheckBox.TabIndex = 17;
-            this.consentTelemetryCheckBox.Text = "Report telemetry to Red Hat";
-            this.consentTelemetryCheckBox.UseVisualStyleBackColor = true;
-            this.consentTelemetryCheckBox.CheckedChanged += new System.EventHandler(this.consentTelemetryCheckBox_CheckedChanged);
             // 
             // CrcSettingsForm
             // 

--- a/Forms/CrcSettingsForm.Designer.cs
+++ b/Forms/CrcSettingsForm.Designer.cs
@@ -52,15 +52,11 @@
             this.cpusNumBox = new System.Windows.Forms.NumericUpDown();
             this.label11 = new System.Windows.Forms.Label();
             this.PullSecretSelectButton = new System.Windows.Forms.Button();
-            this.BundleSelectButton = new System.Windows.Forms.Button();
             this.label4 = new System.Windows.Forms.Label();
             this.pullSecretTxtBox = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
-            this.bundleTxtBox = new System.Windows.Forms.TextBox();
-            this.label1 = new System.Windows.Forms.Label();
             this.advance_tab = new System.Windows.Forms.TabPage();
-            this.enableExperimentalFeatures = new System.Windows.Forms.CheckBox();
             this.refreshButton2 = new System.Windows.Forms.Button();
             this.applyButton2 = new System.Windows.Forms.Button();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
@@ -74,6 +70,8 @@
             this.SkipCheckUserInHypervAdminsGroup = new System.Windows.Forms.CheckBox();
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.fileRequester = new System.Windows.Forms.OpenFileDialog();
+            this.autostartTrayCheckBox = new System.Windows.Forms.CheckBox();
+            this.consentTelemetryCheckBox = new System.Windows.Forms.CheckBox();
             this.tabs.SuspendLayout();
             this.properties_tab.SuspendLayout();
             this.groupBox2.SuspendLayout();
@@ -92,11 +90,11 @@
             this.tabs.AccessibleName = "Settings tab";
             this.tabs.Controls.Add(this.properties_tab);
             this.tabs.Controls.Add(this.advance_tab);
-            this.tabs.Location = new System.Drawing.Point(7, 7);
-            this.tabs.Margin = new System.Windows.Forms.Padding(2);
+            this.tabs.Location = new System.Drawing.Point(9, 9);
+            this.tabs.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tabs.Name = "tabs";
             this.tabs.SelectedIndex = 0;
-            this.tabs.Size = new System.Drawing.Size(471, 374);
+            this.tabs.Size = new System.Drawing.Size(628, 460);
             this.tabs.TabIndex = 0;
             // 
             // properties_tab
@@ -105,11 +103,11 @@
             this.properties_tab.Controls.Add(this.refreshButton);
             this.properties_tab.Controls.Add(this.groupBox2);
             this.properties_tab.Controls.Add(this.groupBox1);
-            this.properties_tab.Location = new System.Drawing.Point(4, 22);
-            this.properties_tab.Margin = new System.Windows.Forms.Padding(2);
+            this.properties_tab.Location = new System.Drawing.Point(4, 25);
+            this.properties_tab.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.properties_tab.Name = "properties_tab";
-            this.properties_tab.Padding = new System.Windows.Forms.Padding(2);
-            this.properties_tab.Size = new System.Drawing.Size(463, 348);
+            this.properties_tab.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.properties_tab.Size = new System.Drawing.Size(620, 431);
             this.properties_tab.TabIndex = 0;
             this.properties_tab.Text = "Properties";
             this.properties_tab.UseVisualStyleBackColor = true;
@@ -117,10 +115,10 @@
             // applyButton
             // 
             this.applyButton.AccessibleName = "Apply button";
-            this.applyButton.Location = new System.Drawing.Point(393, 323);
-            this.applyButton.Margin = new System.Windows.Forms.Padding(2);
+            this.applyButton.Location = new System.Drawing.Point(524, 398);
+            this.applyButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.applyButton.Name = "applyButton";
-            this.applyButton.Size = new System.Drawing.Size(62, 21);
+            this.applyButton.Size = new System.Drawing.Size(83, 26);
             this.applyButton.TabIndex = 15;
             this.applyButton.Text = "Apply";
             this.applyButton.UseVisualStyleBackColor = true;
@@ -129,10 +127,10 @@
             // refreshButton
             // 
             this.refreshButton.AccessibleName = "Refresh button";
-            this.refreshButton.Location = new System.Drawing.Point(306, 323);
-            this.refreshButton.Margin = new System.Windows.Forms.Padding(2);
+            this.refreshButton.Location = new System.Drawing.Point(408, 398);
+            this.refreshButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.refreshButton.Name = "refreshButton";
-            this.refreshButton.Size = new System.Drawing.Size(60, 21);
+            this.refreshButton.Size = new System.Drawing.Size(80, 26);
             this.refreshButton.TabIndex = 14;
             this.refreshButton.Text = "Refresh";
             this.refreshButton.UseVisualStyleBackColor = true;
@@ -150,11 +148,11 @@
             this.groupBox2.Controls.Add(this.httpProxyTxtBox);
             this.groupBox2.Controls.Add(this.label5);
             this.groupBox2.Controls.Add(this.useProxyTick);
-            this.groupBox2.Location = new System.Drawing.Point(3, 153);
-            this.groupBox2.Margin = new System.Windows.Forms.Padding(2);
+            this.groupBox2.Location = new System.Drawing.Point(4, 188);
+            this.groupBox2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBox2.Size = new System.Drawing.Size(455, 157);
+            this.groupBox2.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.groupBox2.Size = new System.Drawing.Size(607, 193);
             this.groupBox2.TabIndex = 1;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Proxy";
@@ -162,10 +160,10 @@
             // proxyCABrowseButton
             // 
             this.proxyCABrowseButton.AccessibleName = "Proxy CA filerequester";
-            this.proxyCABrowseButton.Location = new System.Drawing.Point(390, 115);
-            this.proxyCABrowseButton.Margin = new System.Windows.Forms.Padding(2);
+            this.proxyCABrowseButton.Location = new System.Drawing.Point(520, 142);
+            this.proxyCABrowseButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.proxyCABrowseButton.Name = "proxyCABrowseButton";
-            this.proxyCABrowseButton.Size = new System.Drawing.Size(62, 22);
+            this.proxyCABrowseButton.Size = new System.Drawing.Size(83, 27);
             this.proxyCABrowseButton.TabIndex = 13;
             this.proxyCABrowseButton.Text = "Select file";
             this.proxyCABrowseButton.UseVisualStyleBackColor = true;
@@ -175,30 +173,28 @@
             // 
             this.proxyCAFileTxtBox.AccessibleName = "Proxy CA file";
             this.proxyCAFileTxtBox.Enabled = false;
-            this.proxyCAFileTxtBox.Location = new System.Drawing.Point(105, 116);
-            this.proxyCAFileTxtBox.Margin = new System.Windows.Forms.Padding(2);
+            this.proxyCAFileTxtBox.Location = new System.Drawing.Point(140, 143);
+            this.proxyCAFileTxtBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.proxyCAFileTxtBox.Name = "proxyCAFileTxtBox";
-            this.proxyCAFileTxtBox.Size = new System.Drawing.Size(260, 20);
+            this.proxyCAFileTxtBox.Size = new System.Drawing.Size(345, 22);
             this.proxyCAFileTxtBox.TabIndex = 12;
             this.proxyCAFileTxtBox.TextChanged += new System.EventHandler(this.proxyCAFileTxtBox_TextChanged);
             // 
             // label8
             // 
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(6, 118);
-            this.label8.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label8.Location = new System.Drawing.Point(8, 145);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(66, 13);
+            this.label8.Size = new System.Drawing.Size(87, 17);
             this.label8.TabIndex = 7;
             this.label8.Text = "Proxy CA file";
             // 
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(6, 89);
-            this.label7.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label7.Location = new System.Drawing.Point(8, 110);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(61, 13);
+            this.label7.Size = new System.Drawing.Size(82, 17);
             this.label7.TabIndex = 6;
             this.label7.Text = "No Proxy(s)";
             // 
@@ -206,10 +202,10 @@
             // 
             this.noProxyTxtBox.AccessibleName = "No proxy";
             this.noProxyTxtBox.Enabled = false;
-            this.noProxyTxtBox.Location = new System.Drawing.Point(105, 89);
-            this.noProxyTxtBox.Margin = new System.Windows.Forms.Padding(2);
+            this.noProxyTxtBox.Location = new System.Drawing.Point(140, 110);
+            this.noProxyTxtBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.noProxyTxtBox.Name = "noProxyTxtBox";
-            this.noProxyTxtBox.Size = new System.Drawing.Size(260, 20);
+            this.noProxyTxtBox.Size = new System.Drawing.Size(345, 22);
             this.noProxyTxtBox.TabIndex = 11;
             this.noProxyTxtBox.TextChanged += new System.EventHandler(this.noProxyTxtBox_TextChanged);
             // 
@@ -217,20 +213,19 @@
             // 
             this.httpsProxyTxtBox.AccessibleName = "HTTPS proxy";
             this.httpsProxyTxtBox.Enabled = false;
-            this.httpsProxyTxtBox.Location = new System.Drawing.Point(105, 63);
-            this.httpsProxyTxtBox.Margin = new System.Windows.Forms.Padding(2);
+            this.httpsProxyTxtBox.Location = new System.Drawing.Point(140, 78);
+            this.httpsProxyTxtBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.httpsProxyTxtBox.Name = "httpsProxyTxtBox";
-            this.httpsProxyTxtBox.Size = new System.Drawing.Size(260, 20);
+            this.httpsProxyTxtBox.Size = new System.Drawing.Size(345, 22);
             this.httpsProxyTxtBox.TabIndex = 10;
             this.httpsProxyTxtBox.TextChanged += new System.EventHandler(this.httpsProxyTxtBox_TextChanged);
             // 
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(6, 63);
-            this.label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label6.Location = new System.Drawing.Point(8, 78);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(72, 13);
+            this.label6.Size = new System.Drawing.Size(93, 17);
             this.label6.TabIndex = 3;
             this.label6.Text = "HTTPS Proxy";
             // 
@@ -238,20 +233,19 @@
             // 
             this.httpProxyTxtBox.AccessibleName = "HTTP proxy";
             this.httpProxyTxtBox.Enabled = false;
-            this.httpProxyTxtBox.Location = new System.Drawing.Point(105, 37);
-            this.httpProxyTxtBox.Margin = new System.Windows.Forms.Padding(2);
+            this.httpProxyTxtBox.Location = new System.Drawing.Point(140, 46);
+            this.httpProxyTxtBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.httpProxyTxtBox.Name = "httpProxyTxtBox";
-            this.httpProxyTxtBox.Size = new System.Drawing.Size(260, 20);
+            this.httpProxyTxtBox.Size = new System.Drawing.Size(345, 22);
             this.httpProxyTxtBox.TabIndex = 9;
             this.httpProxyTxtBox.TextChanged += new System.EventHandler(this.httpProxyTxtBox_TextChanged);
             // 
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(6, 39);
-            this.label5.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label5.Location = new System.Drawing.Point(8, 48);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(65, 13);
+            this.label5.Size = new System.Drawing.Size(84, 17);
             this.label5.TabIndex = 1;
             this.label5.Text = "HTTP Proxy";
             // 
@@ -259,10 +253,10 @@
             // 
             this.useProxyTick.AccessibleName = "Use proxy";
             this.useProxyTick.AutoSize = true;
-            this.useProxyTick.Location = new System.Drawing.Point(6, 15);
-            this.useProxyTick.Margin = new System.Windows.Forms.Padding(2);
+            this.useProxyTick.Location = new System.Drawing.Point(8, 18);
+            this.useProxyTick.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.useProxyTick.Name = "useProxyTick";
-            this.useProxyTick.Size = new System.Drawing.Size(74, 17);
+            this.useProxyTick.Size = new System.Drawing.Size(94, 21);
             this.useProxyTick.TabIndex = 8;
             this.useProxyTick.Text = "Use Proxy";
             this.useProxyTick.UseVisualStyleBackColor = true;
@@ -270,6 +264,7 @@
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.consentTelemetryCheckBox);
             this.groupBox1.Controls.Add(this.label23);
             this.groupBox1.Controls.Add(this.label22);
             this.groupBox1.Controls.Add(this.diskSizeNumBox);
@@ -277,18 +272,15 @@
             this.groupBox1.Controls.Add(this.cpusNumBox);
             this.groupBox1.Controls.Add(this.label11);
             this.groupBox1.Controls.Add(this.PullSecretSelectButton);
-            this.groupBox1.Controls.Add(this.BundleSelectButton);
             this.groupBox1.Controls.Add(this.label4);
             this.groupBox1.Controls.Add(this.pullSecretTxtBox);
             this.groupBox1.Controls.Add(this.label3);
             this.groupBox1.Controls.Add(this.label2);
-            this.groupBox1.Controls.Add(this.bundleTxtBox);
-            this.groupBox1.Controls.Add(this.label1);
-            this.groupBox1.Location = new System.Drawing.Point(3, 3);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(2);
+            this.groupBox1.Location = new System.Drawing.Point(4, 4);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBox1.Size = new System.Drawing.Size(455, 146);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.groupBox1.Size = new System.Drawing.Size(607, 180);
             this.groupBox1.TabIndex = 0;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "General";
@@ -296,38 +288,36 @@
             // label23
             // 
             this.label23.AutoSize = true;
-            this.label23.Location = new System.Drawing.Point(148, 119);
-            this.label23.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label23.Location = new System.Drawing.Point(197, 121);
             this.label23.Name = "label23";
-            this.label23.Size = new System.Drawing.Size(22, 13);
+            this.label23.Size = new System.Drawing.Size(28, 17);
             this.label23.TabIndex = 16;
             this.label23.Text = "GB";
             // 
             // label22
             // 
             this.label22.AutoSize = true;
-            this.label22.Location = new System.Drawing.Point(4, 118);
-            this.label22.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label22.Location = new System.Drawing.Point(5, 120);
             this.label22.Name = "label22";
-            this.label22.Size = new System.Drawing.Size(51, 13);
+            this.label22.Size = new System.Drawing.Size(66, 17);
             this.label22.TabIndex = 15;
             this.label22.Text = "Disk Size";
             // 
             // diskSizeNumBox
             // 
             this.diskSizeNumBox.AccessibleName = "Disk size";
-            this.diskSizeNumBox.Location = new System.Drawing.Point(79, 117);
-            this.diskSizeNumBox.Margin = new System.Windows.Forms.Padding(2);
+            this.diskSizeNumBox.Location = new System.Drawing.Point(105, 119);
+            this.diskSizeNumBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.diskSizeNumBox.Name = "diskSizeNumBox";
-            this.diskSizeNumBox.Size = new System.Drawing.Size(65, 20);
+            this.diskSizeNumBox.Size = new System.Drawing.Size(87, 22);
             this.diskSizeNumBox.TabIndex = 7;
             this.diskSizeNumBox.ValueChanged += new System.EventHandler(this.diskSizeNumBox_ValueChanged);
             // 
             // memoryNumBox
             // 
             this.memoryNumBox.AccessibleName = "Memory";
-            this.memoryNumBox.Location = new System.Drawing.Point(79, 64);
-            this.memoryNumBox.Margin = new System.Windows.Forms.Padding(2);
+            this.memoryNumBox.Location = new System.Drawing.Point(105, 53);
+            this.memoryNumBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.memoryNumBox.Maximum = new decimal(new int[] {
             20000,
             0,
@@ -339,7 +329,7 @@
             0,
             0});
             this.memoryNumBox.Name = "memoryNumBox";
-            this.memoryNumBox.Size = new System.Drawing.Size(65, 20);
+            this.memoryNumBox.Size = new System.Drawing.Size(87, 22);
             this.memoryNumBox.TabIndex = 4;
             this.memoryNumBox.Value = new decimal(new int[] {
             9126,
@@ -351,15 +341,15 @@
             // cpusNumBox
             // 
             this.cpusNumBox.AccessibleName = "vCPUs";
-            this.cpusNumBox.Location = new System.Drawing.Point(79, 38);
-            this.cpusNumBox.Margin = new System.Windows.Forms.Padding(2);
+            this.cpusNumBox.Location = new System.Drawing.Point(105, 21);
+            this.cpusNumBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.cpusNumBox.Minimum = new decimal(new int[] {
             4,
             0,
             0,
             0});
             this.cpusNumBox.Name = "cpusNumBox";
-            this.cpusNumBox.Size = new System.Drawing.Size(65, 20);
+            this.cpusNumBox.Size = new System.Drawing.Size(87, 22);
             this.cpusNumBox.TabIndex = 3;
             this.cpusNumBox.Value = new decimal(new int[] {
             4,
@@ -371,132 +361,83 @@
             // label11
             // 
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(147, 66);
-            this.label11.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label11.Location = new System.Drawing.Point(196, 55);
             this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(23, 13);
+            this.label11.Size = new System.Drawing.Size(28, 17);
             this.label11.TabIndex = 11;
             this.label11.Text = "MB";
             // 
             // PullSecretSelectButton
             // 
             this.PullSecretSelectButton.AccessibleName = "PullSecret filerequester";
-            this.PullSecretSelectButton.Location = new System.Drawing.Point(390, 87);
-            this.PullSecretSelectButton.Margin = new System.Windows.Forms.Padding(2);
+            this.PullSecretSelectButton.Location = new System.Drawing.Point(520, 82);
+            this.PullSecretSelectButton.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.PullSecretSelectButton.Name = "PullSecretSelectButton";
-            this.PullSecretSelectButton.Size = new System.Drawing.Size(62, 21);
+            this.PullSecretSelectButton.Size = new System.Drawing.Size(83, 26);
             this.PullSecretSelectButton.TabIndex = 6;
             this.PullSecretSelectButton.Text = "Select file";
             this.PullSecretSelectButton.UseVisualStyleBackColor = true;
             this.PullSecretSelectButton.Click += new System.EventHandler(this.PullSecretSelectButton_Click);
             // 
-            // BundleSelectButton
-            // 
-            this.BundleSelectButton.AccessibleName = "Bundle filerequester";
-            this.BundleSelectButton.Location = new System.Drawing.Point(390, 10);
-            this.BundleSelectButton.Margin = new System.Windows.Forms.Padding(2);
-            this.BundleSelectButton.Name = "BundleSelectButton";
-            this.BundleSelectButton.Size = new System.Drawing.Size(62, 20);
-            this.BundleSelectButton.TabIndex = 2;
-            this.BundleSelectButton.Text = "Select file";
-            this.BundleSelectButton.UseVisualStyleBackColor = true;
-            this.BundleSelectButton.Click += new System.EventHandler(this.BundleSelectButton_Click);
-            // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(4, 91);
-            this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label4.Location = new System.Drawing.Point(5, 87);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(72, 13);
+            this.label4.Size = new System.Drawing.Size(96, 17);
             this.label4.TabIndex = 7;
             this.label4.Text = "Pull secret file";
             // 
             // pullSecretTxtBox
             // 
             this.pullSecretTxtBox.AccessibleName = "PullSecret location";
-            this.pullSecretTxtBox.Location = new System.Drawing.Point(79, 90);
-            this.pullSecretTxtBox.Margin = new System.Windows.Forms.Padding(2);
+            this.pullSecretTxtBox.Location = new System.Drawing.Point(105, 86);
+            this.pullSecretTxtBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.pullSecretTxtBox.Name = "pullSecretTxtBox";
-            this.pullSecretTxtBox.Size = new System.Drawing.Size(285, 20);
+            this.pullSecretTxtBox.Size = new System.Drawing.Size(379, 22);
             this.pullSecretTxtBox.TabIndex = 5;
             this.pullSecretTxtBox.TextChanged += new System.EventHandler(this.pullSecretTxtBox_TextChanged);
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(4, 64);
-            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label3.Location = new System.Drawing.Point(5, 53);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(44, 13);
+            this.label3.Size = new System.Drawing.Size(58, 17);
             this.label3.TabIndex = 4;
             this.label3.Text = "Memory";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(4, 38);
-            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label2.Location = new System.Drawing.Point(5, 21);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(34, 13);
+            this.label2.Size = new System.Drawing.Size(43, 17);
             this.label2.TabIndex = 2;
             this.label2.Text = "CPUs";
             // 
-            // bundleTxtBox
-            // 
-            this.bundleTxtBox.AccessibleName = "Bundle location";
-            this.bundleTxtBox.Location = new System.Drawing.Point(79, 11);
-            this.bundleTxtBox.Margin = new System.Windows.Forms.Padding(2);
-            this.bundleTxtBox.Name = "bundleTxtBox";
-            this.bundleTxtBox.Size = new System.Drawing.Size(285, 20);
-            this.bundleTxtBox.TabIndex = 1;
-            this.bundleTxtBox.TextChanged += new System.EventHandler(this.bundleTxtBox_TextChanged);
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(4, 13);
-            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(40, 13);
-            this.label1.TabIndex = 0;
-            this.label1.Text = "Bundle";
-            // 
             // advance_tab
             // 
-            this.advance_tab.Controls.Add(this.enableExperimentalFeatures);
             this.advance_tab.Controls.Add(this.refreshButton2);
             this.advance_tab.Controls.Add(this.applyButton2);
             this.advance_tab.Controls.Add(this.groupBox4);
             this.advance_tab.Controls.Add(this.groupBox3);
-            this.advance_tab.Location = new System.Drawing.Point(4, 22);
-            this.advance_tab.Margin = new System.Windows.Forms.Padding(2);
+            this.advance_tab.Location = new System.Drawing.Point(4, 25);
+            this.advance_tab.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.advance_tab.Name = "advance_tab";
-            this.advance_tab.Padding = new System.Windows.Forms.Padding(2);
-            this.advance_tab.Size = new System.Drawing.Size(463, 348);
+            this.advance_tab.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.advance_tab.Size = new System.Drawing.Size(620, 431);
             this.advance_tab.TabIndex = 1;
             this.advance_tab.Text = "Advanced";
             this.advance_tab.UseVisualStyleBackColor = true;
             // 
-            // enableExperimentalFeatures
-            // 
-            this.enableExperimentalFeatures.AccessibleName = "Enable experimental features";
-            this.enableExperimentalFeatures.AutoSize = true;
-            this.enableExperimentalFeatures.Location = new System.Drawing.Point(8, 187);
-            this.enableExperimentalFeatures.Margin = new System.Windows.Forms.Padding(2);
-            this.enableExperimentalFeatures.Name = "enableExperimentalFeatures";
-            this.enableExperimentalFeatures.Size = new System.Drawing.Size(162, 17);
-            this.enableExperimentalFeatures.TabIndex = 21;
-            this.enableExperimentalFeatures.Text = "Enable experimental features";
-            this.enableExperimentalFeatures.UseVisualStyleBackColor = true;
-            // 
             // refreshButton2
             // 
             this.refreshButton2.AccessibleName = "Refresh button";
-            this.refreshButton2.Location = new System.Drawing.Point(304, 216);
-            this.refreshButton2.Margin = new System.Windows.Forms.Padding(2);
+            this.refreshButton2.Location = new System.Drawing.Point(405, 266);
+            this.refreshButton2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.refreshButton2.Name = "refreshButton2";
-            this.refreshButton2.Size = new System.Drawing.Size(61, 22);
+            this.refreshButton2.Size = new System.Drawing.Size(81, 27);
             this.refreshButton2.TabIndex = 22;
             this.refreshButton2.Text = "Refresh";
             this.refreshButton2.UseVisualStyleBackColor = true;
@@ -505,10 +446,10 @@
             // applyButton2
             // 
             this.applyButton2.AccessibleName = "Apply button";
-            this.applyButton2.Location = new System.Drawing.Point(393, 216);
-            this.applyButton2.Margin = new System.Windows.Forms.Padding(2);
+            this.applyButton2.Location = new System.Drawing.Point(524, 266);
+            this.applyButton2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.applyButton2.Name = "applyButton2";
-            this.applyButton2.Size = new System.Drawing.Size(63, 22);
+            this.applyButton2.Size = new System.Drawing.Size(84, 27);
             this.applyButton2.TabIndex = 23;
             this.applyButton2.Text = "Apply";
             this.applyButton2.UseVisualStyleBackColor = true;
@@ -516,14 +457,15 @@
             // 
             // groupBox4
             // 
+            this.groupBox4.Controls.Add(this.autostartTrayCheckBox);
             this.groupBox4.Controls.Add(this.nameServerTxtBox);
             this.groupBox4.Controls.Add(this.label9);
             this.groupBox4.Controls.Add(this.disableUpdateCheckBox);
-            this.groupBox4.Location = new System.Drawing.Point(4, 117);
-            this.groupBox4.Margin = new System.Windows.Forms.Padding(2);
+            this.groupBox4.Location = new System.Drawing.Point(5, 144);
+            this.groupBox4.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBox4.Size = new System.Drawing.Size(455, 53);
+            this.groupBox4.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.groupBox4.Size = new System.Drawing.Size(607, 102);
             this.groupBox4.TabIndex = 1;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Misc";
@@ -537,20 +479,19 @@
             "1.0.0.1"});
             this.nameServerTxtBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.nameServerTxtBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.CustomSource;
-            this.nameServerTxtBox.Location = new System.Drawing.Point(338, 21);
-            this.nameServerTxtBox.Margin = new System.Windows.Forms.Padding(2);
+            this.nameServerTxtBox.Location = new System.Drawing.Point(451, 26);
+            this.nameServerTxtBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.nameServerTxtBox.Name = "nameServerTxtBox";
-            this.nameServerTxtBox.Size = new System.Drawing.Size(116, 20);
+            this.nameServerTxtBox.Size = new System.Drawing.Size(153, 22);
             this.nameServerTxtBox.TabIndex = 20;
             this.nameServerTxtBox.TextChanged += new System.EventHandler(this.nameServerTxtBox_TextChanged);
             // 
             // label9
             // 
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(264, 22);
-            this.label9.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label9.Location = new System.Drawing.Point(352, 27);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(64, 13);
+            this.label9.Size = new System.Drawing.Size(85, 17);
             this.label9.TabIndex = 1;
             this.label9.Text = "Nameserver";
             // 
@@ -558,10 +499,10 @@
             // 
             this.disableUpdateCheckBox.AccessibleName = "Disable update check";
             this.disableUpdateCheckBox.AutoSize = true;
-            this.disableUpdateCheckBox.Location = new System.Drawing.Point(3, 21);
-            this.disableUpdateCheckBox.Margin = new System.Windows.Forms.Padding(2);
+            this.disableUpdateCheckBox.Location = new System.Drawing.Point(4, 26);
+            this.disableUpdateCheckBox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.disableUpdateCheckBox.Name = "disableUpdateCheckBox";
-            this.disableUpdateCheckBox.Size = new System.Drawing.Size(130, 17);
+            this.disableUpdateCheckBox.Size = new System.Drawing.Size(166, 21);
             this.disableUpdateCheckBox.TabIndex = 19;
             this.disableUpdateCheckBox.Text = "Disable update check";
             this.disableUpdateCheckBox.UseVisualStyleBackColor = true;
@@ -570,11 +511,11 @@
             // groupBox3
             // 
             this.groupBox3.Controls.Add(this.tableLayoutPanel1);
-            this.groupBox3.Location = new System.Drawing.Point(4, 4);
-            this.groupBox3.Margin = new System.Windows.Forms.Padding(2);
+            this.groupBox3.Location = new System.Drawing.Point(5, 5);
+            this.groupBox3.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBox3.Size = new System.Drawing.Size(455, 109);
+            this.groupBox3.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.groupBox3.Size = new System.Drawing.Size(607, 134);
             this.groupBox3.TabIndex = 0;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Preflight Checks";
@@ -586,23 +527,24 @@
             this.tableLayoutPanel1.Controls.Add(this.SkipCheckWindowsVersion, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.SkipCheckRunningAsAdmin, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.SkipCheckUserInHypervAdminsGroup, 0, 0);
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(4, 17);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(5, 21);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 3;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 12.5F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 12.5F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 12.5F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(448, 79);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(597, 97);
             this.tableLayoutPanel1.TabIndex = 32;
             // 
             // SkipCheckWindowsVersion
             // 
             this.SkipCheckWindowsVersion.AccessibleName = "Skip Windows version check";
             this.SkipCheckWindowsVersion.AutoSize = true;
-            this.SkipCheckWindowsVersion.Location = new System.Drawing.Point(3, 55);
+            this.SkipCheckWindowsVersion.Location = new System.Drawing.Point(4, 68);
+            this.SkipCheckWindowsVersion.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.SkipCheckWindowsVersion.Name = "SkipCheckWindowsVersion";
-            this.SkipCheckWindowsVersion.Size = new System.Drawing.Size(161, 17);
+            this.SkipCheckWindowsVersion.Size = new System.Drawing.Size(204, 21);
             this.SkipCheckWindowsVersion.TabIndex = 18;
             this.SkipCheckWindowsVersion.Text = "Skip windows version check";
             this.SkipCheckWindowsVersion.UseVisualStyleBackColor = true;
@@ -613,9 +555,10 @@
             this.SkipCheckRunningAsAdmin.AccessibleDescription = "Skip check if user is administrator";
             this.SkipCheckRunningAsAdmin.AccessibleName = "Skip administrator check";
             this.SkipCheckRunningAsAdmin.AutoSize = true;
-            this.SkipCheckRunningAsAdmin.Location = new System.Drawing.Point(3, 29);
+            this.SkipCheckRunningAsAdmin.Location = new System.Drawing.Point(4, 36);
+            this.SkipCheckRunningAsAdmin.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.SkipCheckRunningAsAdmin.Name = "SkipCheckRunningAsAdmin";
-            this.SkipCheckRunningAsAdmin.Size = new System.Drawing.Size(201, 17);
+            this.SkipCheckRunningAsAdmin.Size = new System.Drawing.Size(264, 21);
             this.SkipCheckRunningAsAdmin.TabIndex = 17;
             this.SkipCheckRunningAsAdmin.Text = "Skip check for running as admin user";
             this.SkipCheckRunningAsAdmin.UseVisualStyleBackColor = true;
@@ -626,9 +569,10 @@
             this.SkipCheckUserInHypervAdminsGroup.AccessibleDescription = "Skip check if user in Hyper-V administrators group";
             this.SkipCheckUserInHypervAdminsGroup.AccessibleName = "Skip Hyper-V admin check";
             this.SkipCheckUserInHypervAdminsGroup.AutoSize = true;
-            this.SkipCheckUserInHypervAdminsGroup.Location = new System.Drawing.Point(3, 3);
+            this.SkipCheckUserInHypervAdminsGroup.Location = new System.Drawing.Point(4, 4);
+            this.SkipCheckUserInHypervAdminsGroup.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.SkipCheckUserInHypervAdminsGroup.Name = "SkipCheckUserInHypervAdminsGroup";
-            this.SkipCheckUserInHypervAdminsGroup.Size = new System.Drawing.Size(215, 17);
+            this.SkipCheckUserInHypervAdminsGroup.Size = new System.Drawing.Size(282, 21);
             this.SkipCheckUserInHypervAdminsGroup.TabIndex = 16;
             this.SkipCheckUserInHypervAdminsGroup.Text = "Skip user in hyperv admins group check";
             this.SkipCheckUserInHypervAdminsGroup.UseVisualStyleBackColor = true;
@@ -636,6 +580,7 @@
             // 
             // contextMenuStrip1
             // 
+            this.contextMenuStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.contextMenuStrip1.Name = "contextMenuStrip1";
             this.contextMenuStrip1.Size = new System.Drawing.Size(61, 4);
             // 
@@ -644,14 +589,36 @@
             this.fileRequester.FileName = "openFileDialog1";
             this.fileRequester.InitialDirectory = "$env:USERPROFILE";
             // 
+            // autostartTrayCheckBox
+            // 
+            this.autostartTrayCheckBox.AutoSize = true;
+            this.autostartTrayCheckBox.Location = new System.Drawing.Point(4, 66);
+            this.autostartTrayCheckBox.Name = "autostartTrayCheckBox";
+            this.autostartTrayCheckBox.Size = new System.Drawing.Size(199, 21);
+            this.autostartTrayCheckBox.TabIndex = 21;
+            this.autostartTrayCheckBox.Text = "Automatically start on login";
+            this.autostartTrayCheckBox.UseVisualStyleBackColor = true;
+            this.autostartTrayCheckBox.CheckedChanged += new System.EventHandler(this.autostartTrayCheckBox_CheckedChanged);
+            // 
+            // consentTelemetryCheckBox
+            // 
+            this.consentTelemetryCheckBox.AutoSize = true;
+            this.consentTelemetryCheckBox.Location = new System.Drawing.Point(8, 150);
+            this.consentTelemetryCheckBox.Name = "consentTelemetryCheckBox";
+            this.consentTelemetryCheckBox.Size = new System.Drawing.Size(207, 21);
+            this.consentTelemetryCheckBox.TabIndex = 17;
+            this.consentTelemetryCheckBox.Text = "Report telemetry to Red Hat";
+            this.consentTelemetryCheckBox.UseVisualStyleBackColor = true;
+            this.consentTelemetryCheckBox.CheckedChanged += new System.EventHandler(this.consentTelemetryCheckBox_CheckedChanged);
+            // 
             // CrcSettingsForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(484, 387);
+            this.ClientSize = new System.Drawing.Size(645, 476);
             this.Controls.Add(this.tabs);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "CrcSettingsForm";
@@ -668,7 +635,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.memoryNumBox)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.cpusNumBox)).EndInit();
             this.advance_tab.ResumeLayout(false);
-            this.advance_tab.PerformLayout();
             this.groupBox4.ResumeLayout(false);
             this.groupBox4.PerformLayout();
             this.groupBox3.ResumeLayout(false);
@@ -684,15 +650,12 @@
         private System.Windows.Forms.TabPage properties_tab;
         private System.Windows.Forms.TabPage advance_tab;
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.Label label1;
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.Button PullSecretSelectButton;
-        private System.Windows.Forms.Button BundleSelectButton;
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.TextBox pullSecretTxtBox;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.TextBox bundleTxtBox;
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
         private System.Windows.Forms.CheckBox useProxyTick;
         private System.Windows.Forms.Label label7;
@@ -724,6 +687,7 @@
         private System.Windows.Forms.CheckBox SkipCheckWindowsVersion;
         private System.Windows.Forms.CheckBox SkipCheckRunningAsAdmin;
         private System.Windows.Forms.CheckBox SkipCheckUserInHypervAdminsGroup;
-        private System.Windows.Forms.CheckBox enableExperimentalFeatures;
+        private System.Windows.Forms.CheckBox autostartTrayCheckBox;
+        private System.Windows.Forms.CheckBox consentTelemetryCheckBox;
     }
 }

--- a/Forms/CrcSettingsForm.cs
+++ b/Forms/CrcSettingsForm.cs
@@ -60,13 +60,12 @@ namespace CRCTray
         private void loadConfigurationValues(ConfigResult cr)
         {
             // Properties tab configs
-            this.bundleTxtBox.Text = cr.Configs.bundle;
             this.memoryNumBox.Value = cr.Configs.memory;
             this.cpusNumBox.Value = cr.Configs.cpus;
             this.diskSizeNumBox.Value = cr.Configs.DiskSize;
             this.pullSecretTxtBox.Text = cr.Configs.PullSecretFile;
-            //this.networkModeTxtBox.Text = cr.Configs.NetworkMode;
-            this.enableExperimentalFeatures.Checked = cr.Configs.EnableExperimentalFeatures;
+            this.consentTelemetryCheckBox.Checked = cr.Configs.ConsentTelemetry == "no" ? false : true;
+            this.autostartTrayCheckBox.Checked = cr.Configs.AutostartTray;
             // proxy configs
             if (cr.Configs.HttpProxy != String.Empty || cr.Configs.HttpsProxy != String.Empty)
             {
@@ -121,11 +120,6 @@ namespace CRCTray
             fileRequester.FileName = "";
             fileRequester.ShowDialog();
             return fileRequester.FileName;
-        }
-
-        private void BundleSelectButton_Click(object sender, EventArgs e)
-        {
-            this.bundleTxtBox.Text = showAndGetNameFromFileRequester("CRC Bundle|*.crcbundle");
         }
 
         private void PullSecretSelectButton_Click(object sender, EventArgs e)
@@ -210,11 +204,6 @@ namespace CRCTray
                 this.changedConfigs.Add(key, cb.Checked);
         }
 
-        private void bundleTxtBox_TextChanged(object sender, EventArgs e)
-        {
-            handleConfigChangesForTextBoxes("bundle", currentConfig.Configs.bundle, this.bundleTxtBox);
-        }
-
         private void cpusNumBox_ValueChanged(object sender, EventArgs e)
         {
             handleConfigChangesForNumBoxes("cpus", currentConfig.Configs.cpus, this.cpusNumBox);
@@ -233,11 +222,6 @@ namespace CRCTray
         private void diskSizeNumBox_ValueChanged(object sender, EventArgs e)
         {
             handleConfigChangesForNumBoxes("disk-size", currentConfig.Configs.DiskSize, this.diskSizeNumBox);
-        }
-
-        private void enableExperimentalFeatures_CheckedChanged(object sender, EventArgs e)
-        {
-            handleConfigChangesForCheckBoxes("enable-experimental-features", this.enableExperimentalFeatures);
         }
 
         private void httpProxyTxtBox_TextChanged(object sender, EventArgs e)
@@ -283,6 +267,24 @@ namespace CRCTray
         private void SkipCheckUserInHypervAdminsGroup_CheckedChanged(object sender, EventArgs e)
         {
             handleConfigChangesForCheckBoxes("skip-check-user-in-hyperv-group", this.SkipCheckUserInHypervAdminsGroup);
+        }
+
+        private void consentTelemetryCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            var key = "consent-telemetry";
+            var cb = (CheckBox)sender;
+            var value = cb.Checked ? "yes" : "no";
+
+            this.configChanged = true;
+            if (this.changedConfigs.ContainsKey(key))
+                this.changedConfigs[key] = value;
+            else
+                this.changedConfigs.Add(key, value);
+        }
+
+        private void autostartTrayCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            handleConfigChangesForCheckBoxes("autostart-tray", this.autostartTrayCheckBox);
         }
     }
 }

--- a/Forms/PullSecretPickerForm.Designer.cs
+++ b/Forms/PullSecretPickerForm.Designer.cs
@@ -1,0 +1,135 @@
+﻿
+namespace CRCTray
+{
+    partial class PullSecretPickerForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.label1 = new System.Windows.Forms.Label();
+            this.pullSecretPathTextField = new System.Windows.Forms.TextBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.linkLabel1 = new System.Windows.Forms.LinkLabel();
+            this.BrowseButton = new System.Windows.Forms.Button();
+            this.okButton = new System.Windows.Forms.Button();
+            this.browseFile = new System.Windows.Forms.OpenFileDialog();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Location = new System.Drawing.Point(12, 9);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(236, 18);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Please select the pull secret to use";
+            // 
+            // pullSecretPathTextField
+            // 
+            this.pullSecretPathTextField.Location = new System.Drawing.Point(15, 41);
+            this.pullSecretPathTextField.Name = "pullSecretPathTextField";
+            this.pullSecretPathTextField.ReadOnly = true;
+            this.pullSecretPathTextField.Size = new System.Drawing.Size(440, 22);
+            this.pullSecretPathTextField.TabIndex = 1;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(15, 70);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(150, 17);
+            this.label2.TabIndex = 2;
+            this.label2.Text = "Pull secret available at";
+            // 
+            // linkLabel1
+            // 
+            this.linkLabel1.AutoSize = true;
+            this.linkLabel1.Location = new System.Drawing.Point(162, 70);
+            this.linkLabel1.Name = "linkLabel1";
+            this.linkLabel1.Size = new System.Drawing.Size(256, 17);
+            this.linkLabel1.TabIndex = 3;
+            this.linkLabel1.TabStop = true;
+            this.linkLabel1.Text = "cloud.redhat.com/openshift/create/local";
+            // 
+            // BrowseButton
+            // 
+            this.BrowseButton.Location = new System.Drawing.Point(461, 35);
+            this.BrowseButton.Name = "BrowseButton";
+            this.BrowseButton.Size = new System.Drawing.Size(75, 35);
+            this.BrowseButton.TabIndex = 4;
+            this.BrowseButton.Text = "Browse";
+            this.BrowseButton.UseVisualStyleBackColor = true;
+            this.BrowseButton.Click += new System.EventHandler(this.BrowseButton_Click);
+            // 
+            // okButton
+            // 
+            this.okButton.Location = new System.Drawing.Point(461, 100);
+            this.okButton.Name = "okButton";
+            this.okButton.Size = new System.Drawing.Size(75, 31);
+            this.okButton.TabIndex = 5;
+            this.okButton.Text = "OK";
+            this.okButton.UseVisualStyleBackColor = true;
+            this.okButton.Click += new System.EventHandler(this.okButton_Click);
+            // 
+            // browseFile
+            // 
+            this.browseFile.InitialDirectory = "$env:USERPROFILE";
+            // 
+            // PullSecretPickerForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(550, 143);
+            this.Controls.Add(this.okButton);
+            this.Controls.Add(this.BrowseButton);
+            this.Controls.Add(this.linkLabel1);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.pullSecretPathTextField);
+            this.Controls.Add(this.label1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "PullSecretPickerForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Pull Secret Picker";
+            this.Load += new System.EventHandler(this.PullSecretPicker_Load);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.TextBox pullSecretPathTextField;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.LinkLabel linkLabel1;
+        private System.Windows.Forms.Button BrowseButton;
+        private System.Windows.Forms.Button okButton;
+        private System.Windows.Forms.OpenFileDialog browseFile;
+    }
+}

--- a/Forms/PullSecretPickerForm.cs
+++ b/Forms/PullSecretPickerForm.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace CRCTray
+{
+    public partial class PullSecretPickerForm : Form
+    {
+        string pullSecretPath = "";
+        public PullSecretPickerForm()
+        {
+            InitializeComponent();
+        }
+
+        private void PullSecretPicker_Load(object sender, EventArgs e)
+        {
+            Bitmap bm = new Bitmap(Resource.ocp_logo);
+            Icon = Icon.FromHandle(bm.GetHicon());
+        }
+
+        private void BrowseButton_Click(object sender, EventArgs e)
+        {
+            browseFile.ShowDialog();
+            if (browseFile.FileName != "")
+            { 
+                pullSecretPath = browseFile.FileName;
+                pullSecretPathTextField.Text = pullSecretPath;
+            }
+
+            Console.WriteLine("Selected file: {0}", pullSecretPath);
+        }
+
+        public String ShowFilePicker()
+        {
+            base.ShowDialog();
+            return pullSecretPath;
+        }
+
+        private void okButton_Click(object sender, EventArgs e)
+        {
+            Hide();
+        }
+    }
+}

--- a/Forms/PullSecretPickerForm.resx
+++ b/Forms/PullSecretPickerForm.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="browseFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/Forms/StatusForm.Designer.cs
+++ b/Forms/StatusForm.Designer.cs
@@ -108,7 +108,7 @@
             this.CrcStatus.RightToLeft = System.Windows.Forms.RightToLeft.No;
             this.CrcStatus.Size = new System.Drawing.Size(278, 23);
             this.CrcStatus.TabIndex = 1;
-            this.CrcStatus.Text = "||||||||";
+            this.CrcStatus.Text = "Unknown";
             this.CrcStatus.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // OpenShiftStatus
@@ -124,7 +124,7 @@
             this.OpenShiftStatus.Name = "OpenShiftStatus";
             this.OpenShiftStatus.Size = new System.Drawing.Size(278, 23);
             this.OpenShiftStatus.TabIndex = 2;
-            this.OpenShiftStatus.Text = "||||||||";
+            this.OpenShiftStatus.Text = "Unknown";
             this.OpenShiftStatus.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // DiskUsage
@@ -140,7 +140,7 @@
             this.DiskUsage.RightToLeft = System.Windows.Forms.RightToLeft.No;
             this.DiskUsage.Size = new System.Drawing.Size(278, 23);
             this.DiskUsage.TabIndex = 3;
-            this.DiskUsage.Text = "||||||||";
+            this.DiskUsage.Text = "Unknown";
             this.DiskUsage.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // CacheUsage
@@ -156,7 +156,7 @@
             this.CacheUsage.Name = "CacheUsage";
             this.CacheUsage.Size = new System.Drawing.Size(278, 23);
             this.CacheUsage.TabIndex = 4;
-            this.CacheUsage.Text = "||||||||";
+            this.CacheUsage.Text = "Unknown";
             this.CacheUsage.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // tableLayoutPanel1
@@ -213,12 +213,12 @@
             this.CacheFolder.Name = "CacheFolder";
             this.CacheFolder.Size = new System.Drawing.Size(278, 27);
             this.CacheFolder.TabIndex = 5;
-            this.CacheFolder.Text = "||||||||";
+            this.CacheFolder.Text = "Unknown";
             this.CacheFolder.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // StatusForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 17F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(504, 119);
             this.Controls.Add(this.tableLayoutPanel1);

--- a/Forms/StatusForm.Designer.cs
+++ b/Forms/StatusForm.Designer.cs
@@ -39,6 +39,8 @@
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.label1 = new System.Windows.Forms.Label();
             this.CacheFolder = new System.Windows.Forms.Label();
+            this.logsTextBox = new System.Windows.Forms.TextBox();
+            this.label6 = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -50,7 +52,7 @@
             this.label2.Location = new System.Drawing.Point(6, 0);
             this.label2.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(202, 23);
+            this.label2.Size = new System.Drawing.Size(241, 23);
             this.label2.TabIndex = 1;
             this.label2.Text = "CodeReady Containers Status";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -63,7 +65,7 @@
             this.label3.Location = new System.Drawing.Point(6, 23);
             this.label3.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(202, 23);
+            this.label3.Size = new System.Drawing.Size(241, 23);
             this.label3.TabIndex = 2;
             this.label3.Text = "OpenShift Status";
             this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -76,7 +78,7 @@
             this.label4.Location = new System.Drawing.Point(6, 46);
             this.label4.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(202, 23);
+            this.label4.Size = new System.Drawing.Size(241, 23);
             this.label4.TabIndex = 3;
             this.label4.Text = "Disk Usage";
             this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -89,7 +91,7 @@
             this.label5.Location = new System.Drawing.Point(6, 69);
             this.label5.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(202, 23);
+            this.label5.Size = new System.Drawing.Size(241, 23);
             this.label5.TabIndex = 4;
             this.label5.Text = "Cache Usage";
             this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -102,11 +104,11 @@
             this.CrcStatus.AutoSize = true;
             this.CrcStatus.Dock = System.Windows.Forms.DockStyle.Fill;
             this.CrcStatus.Font = new System.Drawing.Font("Segoe UI", 9.857143F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.CrcStatus.Location = new System.Drawing.Point(220, 0);
+            this.CrcStatus.Location = new System.Drawing.Point(259, 0);
             this.CrcStatus.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.CrcStatus.Name = "CrcStatus";
             this.CrcStatus.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.CrcStatus.Size = new System.Drawing.Size(278, 23);
+            this.CrcStatus.Size = new System.Drawing.Size(329, 23);
             this.CrcStatus.TabIndex = 1;
             this.CrcStatus.Text = "Unknown";
             this.CrcStatus.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -119,10 +121,10 @@
             this.OpenShiftStatus.AutoSize = true;
             this.OpenShiftStatus.Dock = System.Windows.Forms.DockStyle.Fill;
             this.OpenShiftStatus.Font = new System.Drawing.Font("Segoe UI", 9.857143F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.OpenShiftStatus.Location = new System.Drawing.Point(220, 23);
+            this.OpenShiftStatus.Location = new System.Drawing.Point(259, 23);
             this.OpenShiftStatus.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.OpenShiftStatus.Name = "OpenShiftStatus";
-            this.OpenShiftStatus.Size = new System.Drawing.Size(278, 23);
+            this.OpenShiftStatus.Size = new System.Drawing.Size(329, 23);
             this.OpenShiftStatus.TabIndex = 2;
             this.OpenShiftStatus.Text = "Unknown";
             this.OpenShiftStatus.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -134,11 +136,11 @@
             this.DiskUsage.AccessibleRole = System.Windows.Forms.AccessibleRole.Text;
             this.DiskUsage.Dock = System.Windows.Forms.DockStyle.Fill;
             this.DiskUsage.Font = new System.Drawing.Font("Segoe UI", 9.857143F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.DiskUsage.Location = new System.Drawing.Point(220, 46);
+            this.DiskUsage.Location = new System.Drawing.Point(259, 46);
             this.DiskUsage.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.DiskUsage.Name = "DiskUsage";
             this.DiskUsage.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.DiskUsage.Size = new System.Drawing.Size(278, 23);
+            this.DiskUsage.Size = new System.Drawing.Size(329, 23);
             this.DiskUsage.TabIndex = 3;
             this.DiskUsage.Text = "Unknown";
             this.DiskUsage.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -151,10 +153,10 @@
             this.CacheUsage.AutoSize = true;
             this.CacheUsage.Dock = System.Windows.Forms.DockStyle.Fill;
             this.CacheUsage.Font = new System.Drawing.Font("Segoe UI", 9.857143F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.CacheUsage.Location = new System.Drawing.Point(220, 69);
+            this.CacheUsage.Location = new System.Drawing.Point(259, 69);
             this.CacheUsage.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.CacheUsage.Name = "CacheUsage";
-            this.CacheUsage.Size = new System.Drawing.Size(278, 23);
+            this.CacheUsage.Size = new System.Drawing.Size(329, 23);
             this.CacheUsage.TabIndex = 4;
             this.CacheUsage.Text = "Unknown";
             this.CacheUsage.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -174,7 +176,7 @@
             this.tableLayoutPanel1.Controls.Add(this.label3, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.CrcStatus, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.label4, 0, 2);
-            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Top;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(6);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
@@ -184,7 +186,7 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(504, 119);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(594, 119);
             this.tableLayoutPanel1.TabIndex = 9;
             // 
             // label1
@@ -195,7 +197,7 @@
             this.label1.Location = new System.Drawing.Point(6, 92);
             this.label1.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(202, 27);
+            this.label1.Size = new System.Drawing.Size(241, 27);
             this.label1.TabIndex = 11;
             this.label1.Text = "Cache Folder";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -208,19 +210,44 @@
             this.CacheFolder.AutoSize = true;
             this.CacheFolder.Dock = System.Windows.Forms.DockStyle.Fill;
             this.CacheFolder.Font = new System.Drawing.Font("Segoe UI", 9.857143F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.CacheFolder.Location = new System.Drawing.Point(220, 92);
+            this.CacheFolder.Location = new System.Drawing.Point(259, 92);
             this.CacheFolder.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.CacheFolder.Name = "CacheFolder";
-            this.CacheFolder.Size = new System.Drawing.Size(278, 27);
+            this.CacheFolder.Size = new System.Drawing.Size(329, 27);
             this.CacheFolder.TabIndex = 5;
             this.CacheFolder.Text = "Unknown";
             this.CacheFolder.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // logsTextBox
+            // 
+            this.logsTextBox.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.logsTextBox.Location = new System.Drawing.Point(10, 152);
+            this.logsTextBox.Margin = new System.Windows.Forms.Padding(5, 3, 5, 4);
+            this.logsTextBox.Multiline = true;
+            this.logsTextBox.Name = "logsTextBox";
+            this.logsTextBox.ReadOnly = true;
+            this.logsTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Both;
+            this.logsTextBox.Size = new System.Drawing.Size(575, 266);
+            this.logsTextBox.TabIndex = 10;
+            this.logsTextBox.TabStop = false;
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label6.Location = new System.Drawing.Point(10, 129);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(51, 20);
+            this.label6.TabIndex = 11;
+            this.label6.Text = "Logs:";
             // 
             // StatusForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 17F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(504, 119);
+            this.ClientSize = new System.Drawing.Size(594, 431);
+            this.Controls.Add(this.label6);
+            this.Controls.Add(this.logsTextBox);
             this.Controls.Add(this.tableLayoutPanel1);
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.142858F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
@@ -235,6 +262,7 @@
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -250,5 +278,7 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Label CacheFolder;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.TextBox logsTextBox;
+        private System.Windows.Forms.Label label6;
     }
 }

--- a/Forms/StatusForm.cs
+++ b/Forms/StatusForm.cs
@@ -19,13 +19,10 @@ namespace CRCTray
             Bitmap bm = new Bitmap(Resource.ocp_logo);
             Icon = Icon.FromHandle(bm.GetHicon());
             Text = @"Detailed Status";
-            
+            Console.WriteLine("For loaded");
             
             this.FormClosing += StatusForm_Closing;
-            //Activated += GetStatus;
-
-            //VisibleChanged += GetStatus;
-            Shown += GetStatus;
+            Activated += GetStatus;
         }
 
         async private void GetStatus(object sender, EventArgs e)
@@ -34,9 +31,10 @@ namespace CRCTray
             if (status != null)
             {
                 var cacheFolderPath = string.Format("{0}\\.crc\\cache", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
-
-                CrcStatus.Text = status.CrcStatus;
-                OpenShiftStatus.Text = status.OpenshiftStatus;
+                if (status.CrcStatus != "" )
+                    CrcStatus.Text = status.CrcStatus;
+                if (status.OpenshiftStatus != "")
+                    OpenShiftStatus.Text = status.OpenshiftStatus;
                 DiskUsage.Text = string.Format("{0} of {1} (Inside the CRC VM)", FileSize.HumanReadable(status.DiskUse), FileSize.HumanReadable(status.DiskSize));
                 CacheUsage.Text = FileSize.HumanReadable(GetFolderSize.SizeInBytes(cacheFolderPath));
                 CacheFolder.Text = cacheFolderPath;

--- a/Forms/StatusForm.cs
+++ b/Forms/StatusForm.cs
@@ -76,12 +76,17 @@ namespace CRCTray
             long size = 0;
 
             var dirInfo = new DirectoryInfo(path);
-
-            foreach (FileInfo fi in dirInfo.GetFiles("*", SearchOption.AllDirectories))
+            try
             {
-                size += fi.Length;
+                foreach (FileInfo fi in dirInfo.GetFiles("*", SearchOption.AllDirectories))
+                {
+                    size += fi.Length;
+                }
             }
-
+            catch (Exception e)
+            {
+                DisplayMessageBox.Error(string.Format("Unexpected Error, did you run 'crc setup'? Error: {0}", e.Message));
+            }
             return size;
         }
     }

--- a/Forms/StatusForm.cs
+++ b/Forms/StatusForm.cs
@@ -34,7 +34,7 @@ namespace CRCTray
                 if (status.CrcStatus != "" )
                     CrcStatus.Text = status.CrcStatus;
                 if (status.OpenshiftStatus != "")
-                    OpenShiftStatus.Text = status.OpenshiftStatus;
+                    OpenShiftStatus.Text = string.Format("{0} (v{1})", status.OpenshiftStatus, status.OpenshiftVersion);
                 DiskUsage.Text = string.Format("{0} of {1} (Inside the CRC VM)", FileSize.HumanReadable(status.DiskUse), FileSize.HumanReadable(status.DiskSize));
                 CacheUsage.Text = FileSize.HumanReadable(GetFolderSize.SizeInBytes(cacheFolderPath));
                 CacheFolder.Text = cacheFolderPath;

--- a/Forms/StatusForm.cs
+++ b/Forms/StatusForm.cs
@@ -18,11 +18,24 @@ namespace CRCTray
         {
             Bitmap bm = new Bitmap(Resource.ocp_logo);
             Icon = Icon.FromHandle(bm.GetHicon());
-            Text = @"Detailed Status";
+            Text = @"Status and Logs";
             Console.WriteLine("For loaded");
             
             this.FormClosing += StatusForm_Closing;
             Activated += GetStatus;
+            // Update logs
+            UpdateLogs();
+
+            var timer = new Timer();
+            timer.Interval = 3000; // 3 seconds
+            timer.Enabled = true;
+            timer.Tick += Timer_Tick;
+        }
+
+        private void Timer_Tick(object sender, EventArgs e)
+        {
+            Console.WriteLine("Updating logs");
+            UpdateLogs();
         }
 
         async private void GetStatus(object sender, EventArgs e)
@@ -45,6 +58,17 @@ namespace CRCTray
         {
             this.Hide();
             e.Cancel = true;
+        }
+
+        private void UpdateLogs()
+        {
+            var logs = TaskHandlers.GetDaemonLogs();
+            var messages = string.Join("\r\n", logs.Messages);
+            if (logsTextBox.Text == messages)
+                return;
+            logsTextBox.Text = messages;
+            logsTextBox.SelectionStart = logsTextBox.Text.Length;
+            logsTextBox.ScrollToCaret();
         }
     }
 

--- a/Helpers/Handlers.cs
+++ b/Helpers/Handlers.cs
@@ -91,5 +91,9 @@ namespace CRCTray.Helpers
             return WebConsole();
         }
 
+        public static Logs GetDaemonLogs()
+        {
+            return getResultsOrShowMessage(DaemonCommander.GetLogs);
+        }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -316,7 +316,7 @@ namespace CRCTray
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.RedirectStandardInput = true;
             process.StartInfo.FileName = string.Format("{0}\\{1}\\crc.exe",
-                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), @"CodeReady Containers");
+                Environment.GetEnvironmentVariable("ProgramW6432"), @"CodeReady Containers");
 #if DEBUG
             process.StartInfo.FileName = string.Format("{0}\\bin\\crc.exe", Environment.GetEnvironmentVariable("GOPATH"));
 #endif

--- a/Program.cs
+++ b/Program.cs
@@ -265,7 +265,7 @@ namespace CRCTray
             if (!string.IsNullOrEmpty(statusResult.CrcStatus))
                 status.Text = statusResult.CrcStatus;
             else
-                status.Text = @"Unknown";
+                status.Text = @"Stopped";
 
             EnableMenuItems();
         }

--- a/Program.cs
+++ b/Program.cs
@@ -257,7 +257,7 @@ namespace CRCTray
         private void ExitMenu_Click(object sender, EventArgs e)
         {
             notifyIcon.Visible = false;
-            Application.Exit();
+            QuitApp();
         }
 
         private void ShowAboutForm(object sender, EventArgs e)

--- a/Program.cs
+++ b/Program.cs
@@ -331,6 +331,7 @@ namespace CRCTray
             catch (Exception e)
             {
                 DisplayMessageBox.Error(string.Format("Cannot start the daemon, Check the logs and restart the application, Error: {0}", e.Message));
+                QuitApp();
             }
             process.WaitForExit();
             if (process.ExitCode == 2)
@@ -341,6 +342,14 @@ namespace CRCTray
             {
                 DisplayMessageBox.Error("Daemon crashed, check the logs and restart the application");
             }
+            QuitApp();
+        }
+
+        private void QuitApp()
+        {
+            notifyIcon.Visible = false;
+            notifyIcon.Dispose();
+            Environment.Exit(-1);
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -101,7 +101,7 @@ namespace CRCTray
 
             cm.Items.Add(new ToolStripSeparator());
             // Detailed status menu
-            detailedStatusMenu = cm.Items.Add(@"Detailed Status");
+            detailedStatusMenu = cm.Items.Add(@"Status and Logs");
             detailedStatusMenu.Click += ShowDetailedStatusForm;
             cm.Items.Add(new ToolStripSeparator());
 

--- a/crc-tray.csproj
+++ b/crc-tray.csproj
@@ -239,6 +239,12 @@
     <Compile Include="Forms\AboutForm.Designer.cs">
       <DependentUpon>AboutForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="Forms\PullSecretPickerForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Forms\PullSecretPickerForm.Designer.cs">
+      <DependentUpon>PullSecretPickerForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="Helpers\Handlers.cs" />
     <Compile Include="Communication\ResponseClasses.cs" />
     <Compile Include="Communication\UnixEndPoint.cs" />
@@ -268,6 +274,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\CrcSettingsForm.resx">
       <DependentUpon>CrcSettingsForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Forms\PullSecretPickerForm.resx">
+      <DependentUpon>PullSecretPickerForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\StatusForm.resx">
       <DependentUpon>StatusForm.cs</DependentUpon>


### PR DESCRIPTION
- Setup stdin for the daemon process, so it exits when it sees the stdin disapper
- Poll for status and enable all the menuitems (since we can now cancel a start in action)
- Settings window update (remove bundle and exp. feature option, add autostart tray and consent telemetry option)
- Show openshift version in the status window
- Add pull secret picker (this is using the binary protocol and uses the config api to determine if it should show the picker, therefore it forces the user to download the pull-secret, can't paste in text)
- Add logs view to the status window

Fixes #58
Fixes #69
Fixes #26 

### Screenshot
#### Pull Secret picker
<img src="https://user-images.githubusercontent.com/8885742/118750802-c9bd9600-b87d-11eb-93c7-25127a42409c.PNG" height="160"/>

#### Logs view
<img src="https://user-images.githubusercontent.com/8885742/118759069-ec57ab00-b88d-11eb-9524-3946dbfe93aa.PNG" height="400"/>

