### PR TITLE
Fix 'flickering' of pseudostate in statusform

### DIFF
--- a/Forms/StatusForm.cs
+++ b/Forms/StatusForm.cs
@@ -115,28 +115,22 @@ namespace CRCTray
                 }
                 else
                 {
+                    if (status.Success)
+                    {
+                        if (status.CrcStatus != "")
+                            CrcStatus.Text = status.CrcStatus;
+
+                        if (status.OpenshiftStatus != "")
+                            OpenShiftStatus.Text = StatusText(status);
+                    }
+
                     var cacheFolderPath = string.Format("{0}\\.crc\\cache",
                         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
-
-                    if (status.CrcStatus != "")
-                        CrcStatus.Text = status.CrcStatus;
-
-                    if (status.OpenshiftStatus != "")
-                        OpenShiftStatus.Text = StatusText(status);
 
                     DiskUsage.Text = string.Format("{0} of {1} (Inside the CRC VM)",
                         FileSize.HumanReadable(status.DiskUse), FileSize.HumanReadable(status.DiskSize));
                     CacheUsage.Text = FileSize.HumanReadable(GetFolderSize.SizeInBytes(cacheFolderPath));
                     CacheFolder.Text = cacheFolderPath;
-                }
-            }
-            else
-            {
-                // TODO: workaround for no VM
-                if (CrcStatus.InvokeRequired)
-                {
-                    UpdateReceivedCallback c = UpdateReceived;
-                    Invoke(c, new StatusResult { CrcStatus = InitialState, OpenshiftStatus = "Stopped"});
                 }
             }
         }

--- a/Helpers/Handlers.cs
+++ b/Helpers/Handlers.cs
@@ -89,12 +89,12 @@ namespace CRCTray.Helpers
         {
             StatusResult result = getResultsOrDefault(DaemonCommander.Status);
 
-            if (StatusReceived != null)
-                StatusReceived(result);
-
             // TODO: workaround for daemon returning 500/Error state when no VM exists
             if (result == null)
                 return null;
+
+            if (StatusReceived != null)
+                StatusReceived(result);
 
             lock (_statusChangeLock)
             {


### PR DESCRIPTION
This is to fix:

```
ERRO Cannot load machine: machine crc does not exist
\\.\pipe\crc-http - - [29/Jun/2021:14:19:39 +0800] "GET /api/status HTTP/1.0" 500 47
ERRO Cannot load machine: machine crc does not exist
\\.\pipe\crc-http - - [29/Jun/2021:14:19:39 +0800] "GET /api/status HTTP/1.0" 500 47
ERRO Cannot load machine: machine crc does not exist
\\.\pipe\crc-http - - [29/Jun/2021:14:19:44 +0800] "GET /api/status HTTP/1.0" 500 47
```

in which the daemon returns a 500 (n result is returned), but we do need to have some status shown. In the application we use a the `Success` flag to determine if a call was successful. In this case, the StatusForm can show a psuedostate of `Stopped` instead.

Without this change:

```
                    Invoke(c, new StatusResult { CrcStatus = InitialState, OpenshiftStatus = "Stopped"});
```

will cause the `StatusForm` to flicker `Stopped`, `Running` on failing requests that either timedout or were cancelled.