### PR TITLE
Issue #92 Add pseudostate 'Stopped' when status failed

### DIFF
--- a/CRCTray.cs
+++ b/CRCTray.cs
@@ -52,7 +52,7 @@ namespace CRCTray
             statusPollingTimer.Enabled = true;
             statusPollingTimer.Elapsed += pollStatusTimerEventHandler;
 
-            TaskHandlers.StatusChanged += UpdateReceived;
+            TaskHandlers.StatusChanged += StatusReceived;
             TaskHandlers.StopReceived += StopReceived;
             TaskHandlers.DeleteReceived += DeleteReceived;
 
@@ -279,9 +279,9 @@ namespace CRCTray
             statusForm.Focus();
         }
 
-        private void UpdateReceived(StatusResult statusResult)
+        private void StatusReceived(StatusResult statusResult)
         {
-            status.Text = statusResult.CrcStatus;
+            status.Text = statusResult.Success ? statusResult.CrcStatus : InitialState;
 
             // TODO: enable based on status
             //startMenu.Enabled = false;

--- a/Forms/StatusForm.cs
+++ b/Forms/StatusForm.cs
@@ -21,7 +21,7 @@ namespace CRCTray
         {
             InitializeComponent();
 
-            TaskHandlers.StatusReceived += UpdateReceived;
+            TaskHandlers.StatusReceived += StatusReceived;
             TaskHandlers.StopReceived += StopReceived;
             TaskHandlers.DeleteReceived += DeleteReceived;
         }
@@ -104,13 +104,13 @@ namespace CRCTray
             }
         }
 
-        private void UpdateReceived(StatusResult status)
+        private void StatusReceived(StatusResult status)
         {
             if (status != null)
             {
                 if (CrcStatus.InvokeRequired)
                 {
-                    UpdateReceivedCallback c = UpdateReceived;
+                    UpdateReceivedCallback c = StatusReceived;
                     Invoke(c, status);
                 }
                 else
@@ -122,6 +122,10 @@ namespace CRCTray
 
                         if (status.OpenshiftStatus != "")
                             OpenShiftStatus.Text = StatusText(status);
+                    }
+                    else
+                    {
+                        CrcStatus.Text = InitialState;
                     }
 
                     var cacheFolderPath = string.Format("{0}\\.crc\\cache",


### PR DESCRIPTION
While not necessary for the detailed status dialog, this change will use the `Success` to either use the actual VM state or use an initial pseudostate 'Stopped'.

This change add a specific `Success` check to the tray icon and adds the 'missing' (redundant) false check to the Status dialog.