### PR TITLE
Issue #92 Using Exception around each call to determine success

### DIFF
--- a/Communication/Exceptions.cs
+++ b/Communication/Exceptions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace CRCTray.Communication
+{
+    internal class APIException : Exception
+    {
+        public APIException(string message) : base(message) { }
+
+    }
+
+    internal class CommunicationException : Exception
+    {
+        public CommunicationException(string message) : base(message) { }
+
+    }
+
+}

--- a/Communication/ResponseClasses.cs
+++ b/Communication/ResponseClasses.cs
@@ -11,13 +11,10 @@ namespace CRCTray.Communication
         public string OpenshiftVersion { get; set; }
         public long DiskUse { get; set; }
         public long DiskSize { get; set; }
-        public string Error { get; set; }
-        public bool Success { get; set; }
     }
 
     public class LogsResult
     {
-        public bool Success { get; set; }
         public string[] Messages { get; set; }
     }
 
@@ -41,23 +38,17 @@ namespace CRCTray.Communication
     public class StopResult
     {
         public string Name { get; set; }
-        public bool Success { get; set; }
         public int State { get; set; }
-        public string Error { get; set; }
     }
 
     public class DeleteResult
     {
         public string Name { get; set; }
-        public bool Success { get; set; }
-        public string Error { get; set; }
     }
 
     public class ConsoleResult
     {
         public ClusterConfig ClusterConfig { get; set; }
-        public bool Success { get; set; }
-        public string Error { get; set; }
     }
 
     public class VersionResult
@@ -65,10 +56,9 @@ namespace CRCTray.Communication
         public string CrcVersion { get; set; }
         public string CommitSha { get; set; }
         public string OpenshiftVersion { get; set; }
-        public bool Success { get; set; }
     }
 
-    struct Config
+    public class Config
     {
         [JsonPropertyName("bundle")]
         public string bundle { get; set; }
@@ -152,15 +142,13 @@ namespace CRCTray.Communication
         public bool SkipCheckWindowsVersion { get; set; }
     }
 
-    struct ConfigResult
+    public class ConfigResult
     {
-        public string Error { get; set; }
         public Config Configs { get; set; }
     }
 
-    struct SetUnsetConfig
+    public class SetUnsetConfig
     {
-        public string Error { get; set; }
         public string[] Properties { get; set; }
     }
 

--- a/Forms/AboutForm.cs
+++ b/Forms/AboutForm.cs
@@ -29,12 +29,13 @@ namespace CRCTray
 
         private async void GetVersion(object sender, EventArgs e)
         {
-            version = await Task.Run(TaskHandlers.Version);
-            if (version.Success) {
+            try
+            {
+                version = await Task.Run(TaskHandlers.Version);
                 CrcVersionLabel.Text = String.Format("{0}+{1}", version.CrcVersion, version.CommitSha);
                 OcpVersion.Text = version.OpenshiftVersion;
             }
-            else
+            catch
             {
                 TrayIcon.NotifyWarn("Unable to fetch version information from daemon");
             }

--- a/Forms/CrcSettingsForm.cs
+++ b/Forms/CrcSettingsForm.cs
@@ -142,22 +142,22 @@ namespace CRCTray
         // Apply button on properties tab
         private async void ApplyButton_Click(object sender, EventArgs e)
         {
+            // TODO: refactor
+
             if (this.configChanged && changedConfigs.Count > 0) 
             {
-                SetUnsetConfig r = await Task.Run(() => TaskHandlers.SetConfig(changedConfigs));
-                if (r.Error == String.Empty)
-                    TrayIcon.NotifyInfo("Settings Applied");
-                else
-                    TrayIcon.NotifyError(r.Error);
+                await TaskHelpers.TryTaskAndNotify(TaskHandlers.SetConfig, changedConfigs,
+                    "Settings applied",
+                    "Settings not applied",
+                    String.Empty);
             }
 
             if (this.configsNeedingUnset.Count > 0)
             {
-                SetUnsetConfig r = await Task.Run(() => TaskHandlers.UnsetConfig(configsNeedingUnset));
-                if (r.Error == String.Empty)
-                    TrayIcon.NotifyInfo("Settings Applied");
-                else
-                    TrayIcon.NotifyError(r.Error);
+                await TaskHelpers.TryTaskAndNotify(TaskHandlers.UnsetConfig, configsNeedingUnset,
+                    "Settings applied",
+                    "Settings not applied",
+                    String.Empty);
             }
 
             // Load the configs again and reset the change trackers

--- a/Forms/StatusForm.cs
+++ b/Forms/StatusForm.cs
@@ -115,16 +115,15 @@ namespace CRCTray
                 }
                 else
                 {
-                    if (status.Success)
-                    {
-                        if (status.CrcStatus != "")
-                            CrcStatus.Text = status.CrcStatus;
+                    if (status.CrcStatus != "")
+                        CrcStatus.Text = status.CrcStatus;
+                    else
+                        CrcStatus.Text = InitialState;
 
-                        if (status.OpenshiftStatus != "")
-                            OpenShiftStatus.Text = StatusText(status);
-                    }
+                    if (status.OpenshiftStatus != "") 
+                        OpenShiftStatus.Text = StatusText(status);
 
-                    var cacheFolderPath = string.Format("{0}\\.crc\\cache",
+                    var cacheFolderPath = string.Format("{0}\\.crc\\cache", 
                         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
 
                     DiskUsage.Text = string.Format("{0} of {1} (Inside the CRC VM)",
@@ -148,22 +147,36 @@ namespace CRCTray
 
         private void GetStatus()
         {
-            Task.Run(TaskHandlers.Status);
+            try
+            {
+                Task.Run(TaskHandlers.Status);
+            }
+            catch
+            {
+                // Status failed, but ignoring
+            }
         }
 
         private async void GetLogs()
         {
-            var logs = await Task.Run(TaskHandlers.GetDaemonLogs);
-            if (logs != null)
+            try
             {
-                var messages = string.Join("\r\n", logs.Messages);
+                var logs = await Task.Run(TaskHandlers.GetDaemonLogs);
+                if (logs != null)
+                {
+                    var messages = string.Join("\r\n", logs.Messages);
 
-                if (logsTextBox.Text == messages)
-                    return;
+                    if (logsTextBox.Text == messages)
+                        return;
 
-                logsTextBox.Text = messages;
-                logsTextBox.SelectionStart = logsTextBox.Text.Length;
-                logsTextBox.ScrollToCaret();
+                    logsTextBox.Text = messages;
+                    logsTextBox.SelectionStart = logsTextBox.Text.Length;
+                    logsTextBox.ScrollToCaret();
+                }
+            }
+            catch
+            {
+                // Logs failed, but ignoring
             }
         }
     }

--- a/Helpers/DaemonLauncher.cs
+++ b/Helpers/DaemonLauncher.cs
@@ -29,7 +29,7 @@ namespace CRCTray.Helpers
                 process.Start();
                 System.IO.StreamWriter daemonStdinWriter = process.StandardInput;
             }
-            catch (Exception e)
+            catch
             {
                 TrayIcon.NotifyError(@"Cannot start the daemon, Check the logs and restart the application");
  

--- a/Helpers/TaskHelpers.cs
+++ b/Helpers/TaskHelpers.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CRCTray.Communication;
+
+namespace CRCTray.Helpers
+{
+   internal class TaskHelpers
+   {
+
+       public static async Task<T> TryTaskAndNotify<T>(Func<T> function, string successMessage, string failureMessage, string canceledMessage)
+       {
+           try
+           {
+               var result = await Task.Run(function);
+
+               if (!String.IsNullOrEmpty(successMessage))
+                   TrayIcon.NotifyInfo(successMessage);
+
+               return result;
+           }
+           catch (AggregateException ae)
+           {
+               ae.Handle((x) =>
+               {
+                   if (x is CommunicationException) // This we know how to handle.
+                   {
+                       // TODO: start counting and eventually notify
+
+                       return true;
+                   }
+
+                   if (x is APIException) // This we know how to handle.
+                   {
+                       if (!String.IsNullOrEmpty(failureMessage)) 
+                           TrayIcon.NotifyError(
+$@"{failureMessage}
+{x.Message}");
+
+                       return true;
+                   }
+
+                   if (x is TaskCanceledException)
+                   {
+                       if (!String.IsNullOrEmpty(canceledMessage))
+                           TrayIcon.NotifyInfo(canceledMessage);
+
+                       return true;
+                   }
+
+                   return false;
+
+               });
+           }
+
+           return default;
+       }
+
+       public static async Task<T> TryTaskAndNotify<T, TArgs>(Func<TArgs, T> function, TArgs args, string successMessage, string failureMessage, string canceledMessage)
+       {
+           try
+           {
+               var result = await Task.Run(() => function(args));
+
+               if (!String.IsNullOrEmpty(successMessage))
+                   TrayIcon.NotifyInfo(successMessage);
+
+               return result;
+           }
+           catch (AggregateException ae)
+           {
+               ae.Handle((x) =>
+               {
+                   if (x is CommunicationException) // This we know how to handle.
+                   {
+                       // TODO: start counting and eventually notify
+
+                       return true;
+                   }
+
+                   if (x is APIException) // This we know how to handle.
+                   {
+                       if (!String.IsNullOrEmpty(failureMessage))
+                           TrayIcon.NotifyError(
+ $@"{failureMessage}
+{x.Message}");
+
+                       return true;
+                   }
+
+                   if (x is TimeoutException || x is TaskCanceledException )
+                   {
+                       if(!String.IsNullOrEmpty(canceledMessage))
+                           TrayIcon.NotifyInfo(canceledMessage);
+
+                       return true;
+                   }
+
+                   return false;
+
+               });
+           }
+
+           return default;
+       }
+   }
+}

--- a/crc-tray.csproj
+++ b/crc-tray.csproj
@@ -241,6 +241,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Communication\Enums.cs" />
+    <Compile Include="Communication\Exceptions.cs" />
     <Compile Include="Communication\Structs.cs" />
     <Compile Include="Forms\AboutForm.cs">
       <SubType>Form</SubType>
@@ -271,6 +272,7 @@
       <DependentUpon>StatusForm.cs</DependentUpon>
     </Compile>
     <Compile Include="Helpers\TrayIcon.cs" />
+    <Compile Include="Helpers\TaskHelpers.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resource.Designer.cs">


### PR DESCRIPTION
This uses `try/catch` to handle issues from the requests made. AggregateException needs to be handle to pick the known ones  which complicate the codebase, as this is required by the `async` pattern if not using the result messages.