### PR TITLE
Fixes #109 Crashes when daemon is not running

### DIFF
--- a/Forms/CrcSettingsForm.cs
+++ b/Forms/CrcSettingsForm.cs
@@ -27,8 +27,20 @@ namespace CRCTray
         {
             this.changedConfigs = new Dictionary<string, dynamic>();
             this.configsNeedingUnset = new List<string>();
-            currentConfig = await Task.Run(TaskHandlers.ConfigView);
-            loadConfigurationValues(currentConfig);
+
+            currentConfig = await TaskHelpers.TryTaskAndNotify(TaskHandlers.ConfigView,
+                String.Empty,
+                String.Empty,
+                String.Empty);
+            if(currentConfig != null)
+            {
+                loadConfigurationValues(currentConfig);
+            }
+            else
+            {
+                TrayIcon.NotifyError("Unable to read configuration. Is the CRC daemon running?");
+            }
+
             configChanged = false;
         }
 


### PR DESCRIPTION
This wraps the `ConfigView` get from the `SettingsForm` to prevent the tray from crashing when the daemon is not running.