### PR TITLE
Issue #116 #117 fix local creation of the status label

### DIFF
--- a/CRCTray.cs
+++ b/CRCTray.cs
@@ -83,7 +83,7 @@ namespace CRCTray
             cm.AccessibleName = "menu";
 
             // Status Menu
-            ToolStripLabel status = new ToolStripLabel(InitialState); //TODO: actually "Unknown"
+            status = new ToolStripLabel(InitialState); //TODO: actually "Unknown"
             status.AccessibleName = status.Text;
             status.TextChanged += Status_TextChanged;
             status.Enabled = false;
@@ -304,7 +304,7 @@ namespace CRCTray
                 statusForm.Show();
 
             statusForm.Focus();
-        }
+        }   
 
         private void UpdateReceived(StatusResult statusResult)
         {


### PR DESCRIPTION
The local creation of the status label causes the label to not exist globally,
therefore the status events, like Update, Delete, etc will result in a null-
pointer as the variable does not actually exist.

