### PR TITLE
Refactor: Suppress await warnings; eg. for telemetry calls

### DIFF
--- a/CRCTray.cs
+++ b/CRCTray.cs
@@ -62,12 +62,12 @@ namespace CRCTray
 
         private void StartDaemon()
         {
-            TaskHelpers.TryTask(() => DaemonLauncher.Start(QuitApp));
+            _ = TaskHelpers.TryTask(() => DaemonLauncher.Start(QuitApp));
         }
 
         private static void pollStatusTimerEventHandler(object source, System.Timers.ElapsedEventArgs e)
         {
-            TaskHelpers.TryTask(Tasks.Status);
+            _ = TaskHelpers.TryTask(Tasks.Status);
         }
 
         // populate the context menu for tray icon
@@ -150,7 +150,7 @@ namespace CRCTray
 
         private void SettingsMenu_Click(object sender, EventArgs e)
         {
-            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.OpenPreferences);
+            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.OpenPreferences);
 
             if (settingsWindow == null)
                 settingsWindow = new SettingsForm();
@@ -163,7 +163,7 @@ namespace CRCTray
 
         async private void CopyOCLoginForKubeadminMenu_Click(object sender, EventArgs e)
         {
-            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.CopyOCLoginForAdmin);
+            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.CopyOCLoginForAdmin);
 
             try
             {
@@ -179,7 +179,7 @@ namespace CRCTray
 
         async private void CopyOCLoginForDeveloperMenu_Click(object sender, EventArgs e)
         {
-            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.CopyOCLoginForDeveloper);
+            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.CopyOCLoginForDeveloper);
 
             try
             {
@@ -195,7 +195,7 @@ namespace CRCTray
 
         async private void OpenWebConsoleMenu_Click(object sender, EventArgs e)
         {
-            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickOpenConsole);
+            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickOpenConsole);
 
             try
             {
@@ -210,7 +210,7 @@ namespace CRCTray
 
         async private void DeleteMenu_Click(object sender, EventArgs e)
         {
-            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickDelete);
+            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickDelete);
 
             TrayIcon.NotifyInfo(@"Deleting cluster");
 
@@ -222,7 +222,7 @@ namespace CRCTray
 
         async private void StopMenu_Click(object sender, EventArgs e)
         {
-            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickStop);
+            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickStop);
 
             TrayIcon.NotifyInfo(@"Stopping cluster");
 
@@ -234,7 +234,7 @@ namespace CRCTray
 
         async private void StartMenu_Click(object sender, EventArgs e)
         {
-            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickStart);
+            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickStart);
 
             // Check using get-config if pullSecret is configured
             var pullsecret = await TaskHelpers.TryTask(Tasks.GetPullSecret);
@@ -249,7 +249,7 @@ namespace CRCTray
                     return;
                 }
 
-                TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.EnterPullSecret);
+                _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.EnterPullSecret);
 
                 await TaskHelpers.TryTaskAndNotify(Tasks.SetPullSecret, pullSecretContent,
                     "Pull Secret stored",
@@ -270,14 +270,14 @@ namespace CRCTray
 
         private void ExitMenu_Click(object sender, EventArgs e)
         {
-            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.Quit);
+            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.Quit);
 
             QuitApp();
         }
 
         private void ShowAboutForm(object sender, EventArgs e)
         {
-            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.OpenAbout);
+            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.OpenAbout);
 
             if (about == null)
                 about = new AboutForm();
@@ -290,7 +290,7 @@ namespace CRCTray
 
         private void ShowDetailedStatusForm(object sender, EventArgs e)
         {
-            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.OpenStatus);
+            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.OpenStatus);
 
             if (statusForm == null)
                 statusForm = new StatusForm();

--- a/CRCTray.cs
+++ b/CRCTray.cs
@@ -67,7 +67,7 @@ namespace CRCTray
 
         private static void pollStatusTimerEventHandler(object source, System.Timers.ElapsedEventArgs e)
         {
-            _ = TaskHelpers.TryTask(Tasks.Status);
+            TaskHelpers.TryTask(Tasks.Status).NoAwait();
         }
 
         // populate the context menu for tray icon
@@ -150,7 +150,7 @@ namespace CRCTray
 
         private void SettingsMenu_Click(object sender, EventArgs e)
         {
-            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.OpenPreferences);
+            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.OpenPreferences).NoAwait();
 
             if (settingsWindow == null)
                 settingsWindow = new SettingsForm();
@@ -163,7 +163,7 @@ namespace CRCTray
 
         async private void CopyOCLoginForKubeadminMenu_Click(object sender, EventArgs e)
         {
-            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.CopyOCLoginForAdmin);
+            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.CopyOCLoginForAdmin).NoAwait();
 
             try
             {
@@ -179,7 +179,7 @@ namespace CRCTray
 
         async private void CopyOCLoginForDeveloperMenu_Click(object sender, EventArgs e)
         {
-            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.CopyOCLoginForDeveloper);
+            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.CopyOCLoginForDeveloper).NoAwait();
 
             try
             {
@@ -195,7 +195,7 @@ namespace CRCTray
 
         async private void OpenWebConsoleMenu_Click(object sender, EventArgs e)
         {
-            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickOpenConsole);
+            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickOpenConsole).NoAwait();
 
             try
             {
@@ -210,7 +210,7 @@ namespace CRCTray
 
         async private void DeleteMenu_Click(object sender, EventArgs e)
         {
-            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickDelete);
+            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickDelete).NoAwait();
 
             TrayIcon.NotifyInfo(@"Deleting cluster");
 
@@ -222,7 +222,7 @@ namespace CRCTray
 
         async private void StopMenu_Click(object sender, EventArgs e)
         {
-            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickStop);
+            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickStop).NoAwait();
 
             TrayIcon.NotifyInfo(@"Stopping cluster");
 
@@ -234,7 +234,7 @@ namespace CRCTray
 
         async private void StartMenu_Click(object sender, EventArgs e)
         {
-            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickStart);
+            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ClickStart).NoAwait();
 
             // Check using get-config if pullSecret is configured
             var pullsecret = await TaskHelpers.TryTask(Tasks.GetPullSecret);
@@ -249,7 +249,7 @@ namespace CRCTray
                     return;
                 }
 
-                _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.EnterPullSecret);
+                TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.EnterPullSecret).NoAwait();
 
                 await TaskHelpers.TryTaskAndNotify(Tasks.SetPullSecret, pullSecretContent,
                     "Pull Secret stored",
@@ -270,14 +270,14 @@ namespace CRCTray
 
         private void ExitMenu_Click(object sender, EventArgs e)
         {
-            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.Quit);
+            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.Quit).NoAwait();
 
             QuitApp();
         }
 
         private void ShowAboutForm(object sender, EventArgs e)
         {
-            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.OpenAbout);
+            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.OpenAbout).NoAwait();
 
             if (about == null)
                 about = new AboutForm();
@@ -290,7 +290,7 @@ namespace CRCTray
 
         private void ShowDetailedStatusForm(object sender, EventArgs e)
         {
-            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.OpenStatus);
+            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.OpenStatus).NoAwait();
 
             if (statusForm == null)
                 statusForm = new StatusForm();

--- a/Forms/SettingsForm.cs
+++ b/Forms/SettingsForm.cs
@@ -165,7 +165,7 @@ namespace CRCTray
         // Apply button on properties tab
         private async void ApplyButton_Click(object sender, EventArgs e)
         {
-            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ApplyPreferences);
+            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ApplyPreferences).NoAwait();
 
             // TODO: refactor
 

--- a/Forms/SettingsForm.cs
+++ b/Forms/SettingsForm.cs
@@ -165,7 +165,7 @@ namespace CRCTray
         // Apply button on properties tab
         private async void ApplyButton_Click(object sender, EventArgs e)
         {
-            TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ApplyPreferences);
+            _ = TaskHelpers.TryTask(Tasks.SendTelemetry, Actions.ApplyPreferences);
 
             // TODO: refactor
 

--- a/Helpers/TaskExtensions.cs
+++ b/Helpers/TaskExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CRCTray.Helpers
+{
+    public static class TaskExtensions
+    {
+        public static void NoAwait(this Task task)
+        {
+            // Do nothing to suppress not awaited warnings
+        }
+    }
+}

--- a/crc-tray.csproj
+++ b/crc-tray.csproj
@@ -256,6 +256,7 @@
       <DependentUpon>PullSecretForm.cs</DependentUpon>
     </Compile>
     <Compile Include="Helpers\Actions.cs" />
+    <Compile Include="Helpers\TaskExtensions.cs" />
     <Compile Include="Helpers\DaemonLauncher.cs" />
     <Compile Include="Helpers\Tasks.cs" />
     <Compile Include="Communication\ResponseClasses.cs" />


### PR DESCRIPTION
#### Refactor: suppress await/async warning
A warning is shown on build about the call not being awaited. However,
this is not something that is needed in case of the telemetry calls.
Either we can choose to use pragma directives, such as:

```c#
#pragma warning disable 4014
SomeAsyncMethod();
#pragma warning restore 4014
```

or in the chosen case, just use

```c#
_ = SomeAsyncMethod();
```

to discard the return value.


#### Refactor: add extension method to show NoAwait intent

Not only does this suppress the warning, but it also more clearly
indicate the intent that the call is not awaited.

```c#
SomeAsyncMethod().NoAwait();
```
