### PR TITLE
Use `TryTaskWithRetry` to check if pull secret is set

### DIFF
--- a/Helpers/TaskExceptions.cs
+++ b/Helpers/TaskExceptions.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace CRCTray.Helpers
+{
+    internal class RetryableTaskFailedException : Exception
+    {
+        public RetryableTaskFailedException(string message) : base(message) { }
+    }
+}

--- a/crc-tray.csproj
+++ b/crc-tray.csproj
@@ -256,6 +256,7 @@
       <DependentUpon>PullSecretForm.cs</DependentUpon>
     </Compile>
     <Compile Include="Helpers\Actions.cs" />
+    <Compile Include="Helpers\TaskExceptions.cs" />
     <Compile Include="Helpers\TaskExtensions.cs" />
     <Compile Include="Helpers\DaemonLauncher.cs" />
     <Compile Include="Helpers\Tasks.cs" />


### PR DESCRIPTION
- Add TryTaskWithRetry helper method to retry tasks that are canceled or times out
- Use TryTaskWithRetry to check if pull secret is set. Show a error notification in case `RetryableTaskFailedException` is thrown

Closes #130 #128 